### PR TITLE
Added abstractFormatOps for binary compatibility

### DIFF
--- a/play23-json-ops/src/main/scala/play/api/libs/json/ops/JsonImplicits.scala
+++ b/play23-json-ops/src/main/scala/play/api/libs/json/ops/JsonImplicits.scala
@@ -12,6 +12,11 @@ trait JsonImplicits extends ImplicitTupleFormats with JsValueImplicits {
 
   implicit def oformatOps(oformat: OFormat.type): OFormatOps.type = OFormatOps
 
+  // $COVERAGE-OFF$
+  @deprecated("Use abstractJsonOps instead. This only exists for binary compatibility", "1.6.0")
+  def abstractFormatOps(json: Json.type): AbstractJsonOps.type = AbstractJsonOps
+  // $COVERAGE-ON$
+
   implicit def abstractJsonOps(json: Json.type): AbstractJsonOps.type = AbstractJsonOps
 
   implicit def abstractJsonOps(json: TypeKeyExtractor.type): AbstractJsonOps.type = AbstractJsonOps


### PR DESCRIPTION
@rh-nalitkin @nicksovich

Replaces: https://github.com/AudaxHealthInc/play-json-ops/pull/17

I want to get this in before the v2 binary compatibility breaking release.