### PR TITLE
Publish and resolve with maven respository

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Pretty much all of these tools become available when you `import `[`play.api.lib
 
 ## Dependencies
 
-- [scalacheck-ops](https://github.com/jeffmay/scalacheck-ops): for the ability to convert ScalaCheck `Gen` into an `Iterator`
+- [scalacheck-ops](https://github.com/rallyhealth/scalacheck-ops): for the ability to convert ScalaCheck `Gen` into an `Iterator`
 
 # Features
 
@@ -210,7 +210,7 @@ By importing `play.api.libs.json.ops._`, you get access to implicits that provid
 * `Reads` and `Writes` for tuple types by writing the result as a `JsArray`
 * The `JsValue` extension method `.asOrThrow[A]` which throws a better exception that `.as[A]`
 * And handy syntax for the features listed below
-  
+
 ## Automatic Automated Tests
 
 To get free test coverage, just extend `PlayJsonFormatSpec[T]` where `T` is a serializable type that you
@@ -245,7 +245,7 @@ class ExampleFormatSpec extends PlayJsonFormatSpec[Example]
 The following example shows how you can create a Format for the `Generic` trait using `Json.formatAbstract`.
 This method requires an implicit `TypeKeyExtractor[Generic]`, which is used to pull a "key" value from some
 field in the json / model. This key value is then matched on by a provided partial function from key to
-format: `Any => OFormat[_ <: Generic]`.  
+format: `Any => OFormat[_ <: Generic]`.
 
 The pattern works as follows:
 
@@ -330,7 +330,7 @@ Ok, now how the formats look in Json:
   ```json
   [1, "seconds"]
   ```
-  
+
 - `StringDurationFormat`
 
   ```json

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,13 @@ organizationName in ThisBuild := "Rally Health"
 version in ThisBuild := "2.0.0"
 scalaVersion in ThisBuild := "2.11.11"
 
+bintrayOrganization := Some("rallyhealth")
+bintrayRepository := "maven"
+
 licenses in ThisBuild := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 resolvers in ThisBuild += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
-resolvers in ThisBuild += Resolver.bintrayRepo("rallyhealth", "ivy-scala-libs")
+resolvers in ThisBuild += Resolver.bintrayRepo("rallyhealth", "maven")
 
 // don't publish the surrounding multi-project build
 publish := {}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ resolvers += Resolver.url(
 )(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.2.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.6")


### PR DESCRIPTION
@rallyhealth/engineers @rcmurphy @usufruct99 @slustbader 

This should pull scalacheck-ops from the new maven repo: https://bintray.com/rallyhealth/maven

And when we release changes, it will publish to this same repo.