### PR TITLE
Fix repo config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ organizationName in ThisBuild := "Rally Health"
 version in ThisBuild := "2.0.0"
 scalaVersion in ThisBuild := "2.11.11"
 
-bintrayOrganization := Some("rallyhealth")
-bintrayRepository := "maven"
+bintrayOrganization in ThisBuild := Some("rallyhealth")
+bintrayRepository in ThisBuild := "maven"
 
 licenses in ThisBuild := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ name := "play-json-ops-root"
 organization in ThisBuild := "com.rallyhealth"
 organizationName in ThisBuild := "Rally Health"
 
-version in ThisBuild := "2.0.0"
 scalaVersion in ThisBuild := "2.11.11"
 
 bintrayOrganization in ThisBuild := Some("rallyhealth")


### PR DESCRIPTION
@rallyhealth/engineers @rcmurphy @arkban 

I published v2.0.0 under the rallyhealth organization. The code coverage reports are going to the new location: https://coveralls.io/github/rallyhealth/play-json-ops