### PR TITLE
Invalidate implicit resolution of JsonImplicits.formatMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: scala
 scala:
-  - 2.10.6
-  - 2.11.8
+  - 2.11.12
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
-  - sbt clean coverage test coverageReport && sbt coverageAggregate
+  - sbt clean coverage +test coverageReport && sbt coverageAggregate
 after_success:
-  - sbt coveralls
+  # Upload coverage reports to codecov.io
+  - bash <(curl -s https://codecov.io/bash) -t 24961df6-494e-4024-b035-ad2aca2ed706
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
@@ -19,4 +19,3 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
-

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-<a href='https://travis-ci.org/jeffmay/play-json-ops'>
-  <img src='https://travis-ci.org/jeffmay/play-json-ops.svg' alt='Build Status' />
-</a>
-<a href='https://coveralls.io/github/jeffmay/play-json-ops?branch=master'>
-  <img src='https://coveralls.io/repos/jeffmay/play-json-ops/badge.svg?branch=master&service=github' alt='Coverage Status' />
-</a>
+[![Build Status](https://travis-ci.org/rallyhealth/play-json-ops.svg?branch=master)](https://travis-ci.org/rallyhealth/play-json-ops)
+[![codecov](https://codecov.io/gh/rallyhealth/play-json-ops/branch/master/graph/badge.svg)](https://codecov.io/gh/rallyhealth/play-json-ops)
 
 # Play Json Ops
 
@@ -18,9 +14,10 @@ implicits and tools for:
 - UTCFormats for org.joda.time.DateTime
 - Compile-time Json.oformat and Json.owrites macros (Play 2.3 only)
 
-<h1>Versions</h1>
+# Versions
 
-<h2>2.X Branch</h2>
+## 2.X Branch
+
 <table>
   <tr>
     <th></th>

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ def commonProject(id: String): Project = {
     // disable publishing empty ScalaDocs
     publishArtifact in(Compile, packageDoc) := false
 
-  )
+  ).enablePlugins(SemVerPlugin)
 }
 
 def playJsonOps(includePlayVersion: String): Project = {
@@ -49,11 +49,18 @@ def playJsonOps(includePlayVersion: String): Project = {
     case Dependencies.play23Version => "23"
     case Dependencies.play25Version => "25"
   }
+  val scalatestVersion = includePlayVersion match {
+    case Dependencies.play23Version => Dependencies.scalatest2Version
+    case Dependencies.play25Version => Dependencies.scalatest3Version
+  }
   val id = s"play$playSuffix-json-ops"
   commonProject(id).settings(
     libraryDependencies ++= Seq(
       Dependencies.playJson(includePlayVersion)
-    )
+    ) ++ Seq(
+      Dependencies.scalacheckOps(scalatestVersion),
+      Dependencies.scalatest(scalatestVersion)
+    ).map(_ % Test)
   )
 }
 

--- a/play25-json-ops/src/main/scala/play/api/libs/json/ops/JsonImplicits.scala
+++ b/play25-json-ops/src/main/scala/play/api/libs/json/ops/JsonImplicits.scala
@@ -15,11 +15,15 @@ trait JsonImplicits extends ImplicitTupleFormats with JsValueImplicits {
   implicit def abstractJsonOps(json: TypeKeyExtractor.type): AbstractJsonOps.type = AbstractJsonOps
 
   /**
-   * Provides a conversion for a format for generic Map[K, V]. Must have a Format[V] in scope.
-   *
-   * @param readKey a function that converts String to K or throws an exception if the conversion cannot be made.
-   * @param writeKey a function that converts K to a String.
-   */
+    * DEPRECATED AND UNSAFE
+    *
+    * Provides a conversion for a format for generic Map[K, V]. Must have a Format[V] in scope.
+    *
+    * @param readKey a function that converts String to K or throws an exception if the conversion cannot be made.
+    * @param writeKey a function that converts K to a String.
+    */
+  @deprecated("This method uses an unsafe call to .toString by default. " +
+    "It will be removed in the next version.", "1.1.0")
   implicit def formatMap[K, V: Format](
     implicit readKey: String => K, writeKey: K => String = (_: K).toString): Format[Map[K, V]] = {
     val mapReads = Reads.mapReads[V]

--- a/play25-json-ops/src/main/scala/play/api/libs/json/ops/package.scala
+++ b/play25-json-ops/src/main/scala/play/api/libs/json/ops/package.scala
@@ -1,3 +1,40 @@
 package play.api.libs.json
 
-package object ops extends JsonImplicits
+package object ops extends JsonImplicits {
+
+  /**
+    * DEPRECATED AND UNSAFE
+    *
+    * @note this overrides the implicit method to avoid low-priority implicit rules.
+    *
+    * @see [[JsonImplicits.formatMap]] for more details.
+    */
+  @deprecated("This method uses an unsafe call to .toString by default. " +
+    "It will be removed in the next version.", "1.1.0")
+  override def formatMap[K, V: Format](
+    implicit readKey: String => K, writeKey: K => String = (_: K).toString): Format[Map[K, V]] = {
+    super.formatMap
+  }
+
+  /**
+    * Invalidates [[formatMap]] to avoid unsafe behavior by creating ambiguous implicits.
+    */
+  @deprecated("This method is only used to invalidate the implicit resolution of JsonImplicits.formatMap. " +
+    "It will be removed in the next version.", "1.1.0")
+  implicit def invalidateBuggyAndUnsafeFormatMapImplicit1[K, V](implicit readKey: String => K): Format[Map[K, V]] = {
+    throw new UnsupportedOperationException(
+      "This method is only used to invalidate the implicit resolution of JsonImplicits.formatMap."
+    )
+  }
+
+  /**
+    * Invalidates [[formatMap]] to avoid unsafe behavior by creating ambiguous implicits.
+    */
+  @deprecated("This method is only used to invalidate the implicit resolution of JsonImplicits.formatMap. " +
+    "It will be removed in the next version.", "1.1.0")
+  implicit def invalidateBuggyAndUnsafeFormatMapImplicit2[K, V](implicit readKey: String => K): Format[Map[K, V]] = {
+    throw new UnsupportedOperationException(
+      "This method is only used to invalidate the implicit resolution of JsonImplicits.formatMap."
+    )
+  }
+}

--- a/play25-json-ops/src/test/scala/play/api/libs/json/ops/JsonImplicitsSpec.scala
+++ b/play25-json-ops/src/test/scala/play/api/libs/json/ops/JsonImplicitsSpec.scala
@@ -1,0 +1,87 @@
+package play.api.libs.json.ops
+
+import org.scalatest.FreeSpec
+import play.api.libs.json.{Format, Json}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+case class KeyWrapper(key: String)
+
+class JsonImplicitsSpec extends FreeSpec {
+
+  private val exampleJson = Json.obj(
+    "A" -> "value",
+    "B" -> "other"
+  )
+  private val exampleMap = Map(
+    KeyWrapper("A") -> "value",
+    KeyWrapper("B") -> "other"
+  )
+  private val exampleMapFormat = {
+    formatMap[KeyWrapper, String](Format.of[String], KeyWrapper, _.key)
+  }
+
+  "implicit function resolution of formatMap should throw an error on writes" in {
+    implicit val fromString: String => KeyWrapper = KeyWrapper
+    assertDoesNotCompile {
+      """
+      Json.toJson(exampleMap)
+      """
+    }
+  }
+
+  "implicit function resolution of formatMap should throw an error on reads" in {
+    implicit val fromString: String => KeyWrapper = KeyWrapper
+    assertDoesNotCompile {
+      """
+      Json.fromJson[Map[KeyWrapper, String]](exampleJson)
+      """
+    }
+  }
+
+  "implicit conversion resolution of formatMap should throw an error on writes" in {
+    import scala.language.implicitConversions
+    implicit def fromString(key: String): KeyWrapper = KeyWrapper(key)
+    assertDoesNotCompile {
+      """
+      Json.toJson(exampleMap)
+      """
+    }
+  }
+
+  "implicit conversion resolution of formatMap should throw an error on reads" in {
+    import scala.language.implicitConversions
+    implicit def fromString(key: String): KeyWrapper = KeyWrapper(key)
+    assertDoesNotCompile {
+      """
+      Json.fromJson[Map[KeyWrapper, String]](exampleJson)
+      """
+    }
+  }
+
+  "explicit call to write should format the Json correctly" in {
+    assertResult(exampleJson) {
+      exampleMapFormat.writes(exampleMap)
+    }
+  }
+
+  "explicit call to read should read correctly formatted Json" in {
+    assertResult(exampleMap) {
+      exampleMapFormat.reads(exampleJson).recoverTotal { err =>
+        throw InvalidJsonException[Map[KeyWrapper, String]](exampleJson, err)
+      }
+    }
+  }
+
+  "formatter should read every value it writes and write it out the same way" in {
+    forAll { value: Map[String, String] =>
+      val keyWrappedMap = value.map {
+        case (k, v) => (KeyWrapper(k), v)
+      }
+      val json = exampleMapFormat.writes(keyWrappedMap)
+      val parsedMap = exampleMapFormat.reads(json).recoverTotal { err =>
+        throw InvalidJsonException[Map[KeyWrapper, String]](json, err)
+      }
+      assertResult(keyWrappedMap)(parsedMap)
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,3 @@ resolvers += Resolver.url(
 addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.2.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.6")


### PR DESCRIPTION
@vsrally @rallyhealth/engineers 

This method is both `implicit` and unsound. It is a landmine, and we need to remove it ASAP.

This first change will invalidate the implicit resolution of formatMap without breaking binary compatibility.

Future changes will be to add support for an improved version of this implicit, remove support for Play 2.3, and then add support for Play 2.6 and 2.7.0-M1.
