### PR TITLE
Publish all versions of Scala instead of just the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - sbt clean coverage test coverageAggregate coverageOff
 after_success:
   # Upload coverage reports to codecov.io
-  - bash <(curl -s https://codecov.io/bash) -t da106017-e665-49d6-a9b8-6b847b2053f3
+  - bash <(curl -s https://codecov.io/bash) -t 24961df6-494e-4024-b035-ad2aca2ed706
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm


### PR DESCRIPTION
The last update made it possible to run all these versions side-by-side, but there was a bug in the build that caused these to only publish the last defined project.

Tested this change by publishing it locally.