### PR TITLE
Add implicit owritesMap method and make writesMap not implicit to avoid issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ name := "play-json-ops-root"
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
 
-ThisBuild / gitVersioningSnapshotLowerBound := "4.0.0"
-
 ThisBuild / bintrayOrganization := Some("rallyhealth")
 ThisBuild / bintrayRepository := "maven"
 

--- a/play-json-ops-common/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
+++ b/play-json-ops-common/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
@@ -32,9 +32,12 @@ private[ops] class JsonImplicits private[ops] extends ImplicitTupleFormats with 
     }
   }
 
-  implicit def writesMap[K: WritesKey, V: Writes]: Writes[Map[K, V]] = {
+  @deprecated("Use owritesMap instead.", "4.2.0")
+  def writesMap[K: WritesKey, V: Writes]: Writes[Map[K, V]] = owritesMap[K, V]
+
+  implicit def owritesMap[K: WritesKey, V: Writes]: OWrites[Map[K, V]] = {
     val writesK = WritesKey.of[K]
     val stringKeyWriter = Writes.map[V]
-    Writes[Map[K, V]](values => stringKeyWriter.writes(values.map { case (k, v) => (writesK.write(k), v) }))
+    OWrites[Map[K, V]](values => stringKeyWriter.writes(values.map { case (k, v) => (writesK.write(k), v) }))
   }
 }

--- a/play-json-tests-common/src/test/scala/play/api/libs/json/ops/v4/JsonImplicitsSpec.scala
+++ b/play-json-tests-common/src/test/scala/play/api/libs/json/ops/v4/JsonImplicitsSpec.scala
@@ -3,7 +3,7 @@ package play.api.libs.json.ops.v4
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.ops._
 import org.scalatest.FreeSpec
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{Format, Json, OWrites, Writes}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 
 case class KeyWrapper(key: String)
@@ -58,5 +58,13 @@ class JsonImplicitsSpec extends FreeSpec {
       }
       assertResult(keyWrappedMap)(parsedMap)
     }
+  }
+
+  "implicit Writes[Map[Int, String]] should be in scope" in {
+    implicitly[Writes[Map[Int, String]]]
+  }
+
+  "implicit OWrites[Map[Int, String]] should be in scope" in {
+    implicitly[OWrites[Map[Int, String]]]
   }
 }

--- a/play27-json-ops-scala213/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
+++ b/play27-json-ops-scala213/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
@@ -32,9 +32,11 @@ private[ops] class JsonImplicits private[ops] extends ImplicitTupleFormats with 
     }
   }
 
-  implicit def writesMap[K: WritesKey, V: Writes]: Writes[Map[K, V]] = {
+  def writesMap[K: WritesKey, V: Writes]: Writes[Map[K, V]] = owritesMap[K, V]
+
+  implicit def owritesMap[K: WritesKey, V: Writes]: OWrites[Map[K, V]] = {
     val writesK = WritesKey.of[K]
     val stringKeyWriter = Writes.map[V]
-    Writes[Map[K, V]](values => stringKeyWriter.writes(values.map { case (k, v) => (writesK.write(k), v) }))
+    OWrites[Map[K, V]](values => stringKeyWriter.writes(values.map { case (k, v) => (writesK.write(k), v) }))
   }
 }


### PR DESCRIPTION
This will handle situations where an implicit OWrites is needed. This should have been the initial implementation, but writesMap was kept for binary compatibility.

- [x] Add test case to verify fix