### PR TITLE
Upgrade sbt, use dynver and mima plugins, and support Play 2.8 better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.log
 
 # sbt specific
+.bsp
+sbt.json
 .cache
 .history
 .lib/
@@ -14,6 +16,7 @@ project/plugins/project/
 
 # IntelliJ Specific
 .idea
+*.iml
 
 # Scala-IDE specific
 .scala_dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,30 @@
 language: scala
 scala:
-  - 2.13.1
+  - 2.13.5
 jdk:
   - openjdk8
+  - openjdk11
+
+before_script:
+  # Download sbt because Travis can't find it automatically :(
+  - mkdir -p $HOME/.sbt/launchers/1.5.0/
+  - curl -L -o $HOME/.sbt/launchers/1.5.0/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar
 
 script:
-  - sbt clean coverage test coverageAggregate coverageOff
-after_success:
-  # Upload coverage reports to codecov.io
-  - bash <(curl -s https://codecov.io/bash) -t 24961df6-494e-4024-b035-ad2aca2ed706
+  - sbt clean coverage +test coverageAggregate
+  # Upload coverage reports to codecov.io before checking for binary compatibility
+  - bash <(curl -s https://codecov.io/bash)
+  - sbt +mimaReportBinaryIssues
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+# Avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/AbstractJsonOps.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/AbstractJsonOps.scala
@@ -1,0 +1,469 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+import scala.annotation.implicitNotFound
+import scala.language.implicitConversions
+import scala.reflect.runtime.universe._
+
+/**
+ * Provides a mechanism for creating serializers for traits or abstract classes with multiple subclasses.
+ *
+ * The pattern works as follows:
+ *
+ * 1. Create the formats of each of the specific formats using [[AbstractJsonOps.formatWithType]]
+ *    and the [[JsonMacroOps.oformat]] macro.
+ *
+ *    This will append the key field (even if it isn't in the case class constructor args) to the output json.
+ *
+ * 2. Create an implicit [[TypeKeyExtractor]] for the generic trait or abstract class on the companion object
+ *    of that class.
+ *
+ *    This is required for the [[AbstractJsonOps.formatWithType]] to work properly and avoids repeating
+ *    unnecessary boilerplate on each of the specific serializers to write out the key or the generic
+ *    serializer to read the key.
+ *
+ * 3. Finally, define an implicit [[OFormat]] for your generic trait or abstract class using
+ *    [[AbstractJsonOps.formatAbstract]] by providing a partial function from the extracted key (from #2)
+ *    to the specific serializer (from #1). Any unmatched keys will throw an exception.
+ *
+ * Usage:
+ * {{{
+ *   trait Generic {
+ *     def key: String
+ *   }
+ *
+ *   object Generic extends JsonImplicits {
+ *     implicit val extractor: TypeKeyExtractor[Generic] = Json.extractTypeKey[Generic].using(_.key, __ \ "key")
+ *
+ *     implicit val format: OFormat[Generic] = Json.formatAbstract[Generic] {
+ *       case "specific" => OFormat.of[Specific]
+ *       // other subclasses can be keyed into here using the value of the key field on the json / model object
+ *     }
+ *   }
+ *
+ *   case class Specific(value: Int) extends Generic {
+ *     // this key will be written to the json even though the macro doesn't insert it
+ *     def key = "specific"
+ *   }
+ *
+ *   object Specific extends JsonImplicits {
+ *     implicit val format: OFormat[Specific] = Json.formatWithType[Specific, Generic](Json.oformat[Specific])
+ *   }
+ * }}}
+ */
+object AbstractJsonOps {
+
+  // TODO: Warn about overwritten keys?
+  @inline final private def addKeyToModel(key: JsObject, obj: JsObject): JsObject = {
+    if (key.keys.exists(obj.keys.contains)) obj ++ key // overwrite type key value to avoid breaking change
+    else key ++ obj // no conflicting keys, prepend the type key
+  }
+
+  /**
+   * Builds an object format that writes the type key to the json, so that it can be read in
+   * by the [[OFormat]] built from the [[formatAbstract]] method.
+   *
+   * @tparam Abstract the abstract type for looking up the [[TypeKeyExtractor]]
+   */
+  def formatWithTypeKeyOf[Abstract: TypeKeyExtractor]: FormatWithTypeKeyDerivation[Abstract] = {
+    new FormatWithTypeKeyDerivation[Abstract]
+  }
+
+  /**
+   * Creates an object serializer [[OFormat]] that also serialized a type key field.
+   *
+   * The type key field depends on the implicit [[TypeKeyExtractor]] provided.
+   * By serializing this type key, you can use [[formatAbstract]] on a superclass
+   * to match and deserialize this type appropriately.
+   *
+   * Usage:
+   * {{{
+   * object Specific extends JsonImplicits {
+   *   implicit val format: OFormat[Specific] = Json.formatWithType[Specific](Generic.extractor, Json.oformat[Specific])
+   * }
+   * }}}
+   *
+   * @param objFormat the OFormat to add type info to
+   * @tparam Concrete the concrete type to format this as
+   * @return an OFormat that serializes the concrete type with a given type key extractor.
+   */
+  def formatWithType[Concrete](extractor: TypeKeyExtractor[_ >: Concrete], objFormat: OFormat[Concrete]): OFormat[Concrete] = {
+    new OFormat[Concrete] {
+      override def reads(json: JsValue): JsResult[Concrete] = objFormat.reads(json)
+      override def writes(model: Concrete): JsObject = {
+        val obj = objFormat.writes(model)
+        val key = extractor.writeKeyToJson(model)
+        addKeyToModel(key, obj)
+      }
+    }
+  }
+
+  class FormatWithTypeKeyDerivation[Abstract](implicit extractor: TypeKeyExtractor[Abstract]) {
+
+    /**
+     * Creates an object serializer for the given [[Concrete]] type that also serialized a type key field.
+     *
+     * The type key field depends on the implicit [[TypeKeyExtractor]] provided.
+     * By serializing this type key, you can use [[formatAbstract]] on a superclass
+     * to match and deserialize this type appropriately.
+     *
+     * Usage:
+     * {{{
+     * object Specific extends JsonImplicits {
+     *   implicit val format: Format[Specific] = Json.formatWithType[Specific, Generic](Json.oformat[Specific])
+     * }
+     * }}}
+     *
+     * @param objFormat the OFormat to add type info to
+     * @tparam Concrete the concrete type to format this as
+     * @return a [[OFormat]] that serializes the type key as json alongside the given formatter
+     */
+    def addedTo[Concrete <: Abstract](objFormat: OFormat[Concrete]): OFormat[Concrete] = {
+      new OFormat[Concrete] {
+        override def reads(json: JsValue): JsResult[Concrete] = objFormat.reads(json)
+        override def writes(model: Concrete): JsObject = {
+          val obj = objFormat.writes(model)
+          val key = extractor.writeKeyToJson(model)
+          addKeyToModel(key, obj)
+        }
+      }
+    }
+
+    /**
+      * Creates an object serializer for the given [[Concrete]] type that serializes a constant set of values
+      * alongside the type key field.
+      *
+      * @param value the value from which to extract the type key json
+      * @param fields any additional values to serialize alongside the type key
+      * @return an [[OFormat]] that serializes the given value's type key along with any fields given
+      */
+    def pure[Concrete <: Abstract](value: Concrete, fields: JsObject = Json.obj()): OFormat[Concrete] = {
+      new OFormat[Concrete] {
+        override def reads(json: JsValue): JsResult[Concrete] = {
+          extractor.readKeyFromJson(json).flatMap(_ => JsSuccess[Concrete](value))
+        }
+        override def writes(model: Concrete): JsObject = {
+          addKeyToModel(extractor.writeKeyToJson(model), fields)
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates an [[OFormat]] for a generic trait or abstract class by enumerating the formats
+   * of all the subclasses.
+   *
+   * The format will examine a key field as extracted by the [[TypeKeyExtractor]], and then
+   * it will use that format to finish the job of reading / writing the generic type.
+   *
+   * Usage:
+   * {{{
+   * trait Generic {
+   *   def kind: String
+   * }
+   *
+   * object Generic extends JsonImplicits {
+   *   implicit val extractor: TypeKeyExtractor[Generic] = TypeKeyExtractor[Generic](_.kind)
+   *
+   *   implicit val format: Format[Generic] = Json.formatAbstract[Generic] {
+   *     case Specific.kind => OFormat.of[Specific]
+   *     // enumerating all specific subclasses
+   *   }
+   * }
+   * }}}
+   *
+   * @param choose a partial function matching a key value as extracted from the json object
+   *               to the specific [[OFormat]] that should be used to deserialize it
+   * @tparam T the generic type for which to create a format
+   * @return an OFormat that will deserialize the specific subclasses of [[T]] or will throw
+   *         an [[UnrecognizedTypeKeyException]] exception, if the key is not matched by the partial function
+   */
+  def formatAbstract[T : TypeKeyExtractor](choose: PartialFunction[Any, OFormat[_ <: T]]): OFormat[T] =
+    new OFormat[T] {
+
+      /**
+       * The bi-directional binding between Json type key and the associated type serializer.
+       */
+      private[this] val extractor: TypeKeyExtractor[T] = implicitly
+
+      /**
+       * A pre-compiled closure to grab the appropriate format for a given key, or None
+       */
+      private[this] val chooseOrNone: Any => Option[OFormat[_ <: T]] = choose.lift
+
+      /**
+       * Finds the appropriate format for a parsed key.
+       *
+       * @param typeKey the key used to lookup the format
+       * @throws UnrecognizedTypeKeyException if the key has no corresponding format
+       */
+      private def findFormatOrThrow(typeKey: Any): OFormat[T] = {
+        val format = chooseOrNone(typeKey) getOrElse extractor.throwUnrecognizedTypeKey(typeKey)
+        // safe to cast since all subclasses of T should be writable from the provided format
+        format.asInstanceOf[OFormat[T]]
+      }
+
+      /**
+        * Handles errors that arise when a type key maps to the wrong type of formatter.
+        *
+        * @param typeKey the type key for error logging
+        * @param action the action that uses the formatter found by this key
+        */
+      private def findFormatAndHandleExceptions[A](typeKey: Any)(action: OFormat[T] => A): A = {
+        try action(findFormatOrThrow(typeKey))
+        catch {
+          case cce: ClassCastException =>
+            throw new WrongAbstractFormatException(
+              extractor.valueType,
+              typeKey,
+              extractor.keyPath,
+              extractor.keyType,
+              cce
+            )
+        }
+      }
+
+      override def reads(json: JsValue): JsResult[T] = {
+        extractor.readKeyFromJson(json) flatMap { typeKey =>
+          findFormatAndHandleExceptions(typeKey) { format =>
+            format.reads(json)
+          }
+        }
+      }
+
+      override def writes(o: T): JsObject = {
+        val typeKey = extractor.readKeyFromModel(o)
+        val obj = findFormatAndHandleExceptions(typeKey) { format =>
+          format.writes(o)
+        }
+        val jsonKey = extractor.writeKeyToJson(o)
+        addKeyToModel(jsonKey, obj)
+      }
+    }
+
+  /**
+    * Creates an immutable builder for creating a [[TypeKeyExtractor]] for a type.
+    *
+    * @note This doesn't actually create the extractor. It just captures the type of trait
+    *       or abstract class, so that the [[TypeKeyDerivation.usingKeyField]] and
+    *       [[TypeKeyDerivation.usingKeyObject]] methods are easier to define without
+    *       having to provide explicit type arguments.
+    * @tparam T the type of [[TypeKeyExtractor]] to build
+    * @return a [[TypeKeyDerivation]] for building the final extractor
+    */
+  def extractTypeKey[T: TypeTag]: TypeKeyDerivation[T] = new TypeKeyDerivation[T]
+
+  class TypeKeyDerivation[T] private[AbstractJsonOps] (implicit modelTag: TypeTag[T]) {
+
+    /**
+      * Builds a [[TypeKeyExtractor]] for the captured type using the given function from
+      * model to key value and the path in the json to that key.
+      *
+      * @note this requires and implicit [[Format]] of the key value type in order to parse
+      *       the key from the given field in the json.
+      * @param getModelKey a function that extracts the key from the model
+      * @param jsonKeyPath the path in the json to the key
+      * @return a TypeKeyExtractor that uses the given functions to read and write the key
+      *         to the output Json.
+      */
+    def usingKeyField[K: TypeTag: Format](
+      getModelKey: T => K,
+      jsonKeyPath: JsPath
+    ): TypeKeyExtractor[T] = TypeKeyExtractor[T, K](getModelKey, jsonKeyPath)
+
+    /**
+      * A more flexible [[TypeKeyExtractor]] that reads the json into any value and writes it
+      * as a JsObject to be merged with the rest of the model.
+      *
+      * @note the written key is merged at the root with the rest of the model.
+      * @param keyPathReaders a function that extracts the key from json
+      * @param writeKey the function to use to write the key as a JsObject
+      * @return a TypeKeyExtractor that uses the given functions to read and write the key
+      *         to the output Json.
+      */
+    def usingKeyObject(keyPathReaders: (JsPath, Reads[_])*)(writeKey: T => JsObject): TypeKeyExtractor[T] = {
+      new TypeKeyExtractor[T] {
+        override final type Key = Any
+        override def keyTypeTag: TypeTag[Any] = implicitly[TypeTag[Any]]
+        override val keyType: Type = keyTypeTag.tpe
+        override def valueTypeTag: TypeTag[T] = modelTag
+        override val valueType: Type = valueTypeTag.tpe
+        override val keyPath: JsPath = __ // The key is flattened into the main object
+        override def writeKeyToJson(model: T): JsObject = writeKey(model)
+        override def readKeyFromModel(model: T): Key = {
+          val jsonKey = writeKey(model)
+          readKeyFromJson(jsonKey).recoverTotal { err =>
+            throw new JsonTypeKeyReadException(valueType, jsonKey, err)
+          }
+        }
+        override def readKeyFromJson(json: JsValue): JsResult[Key] = {
+          json.validate[JsObject] flatMap { obj =>
+            // Merge all path specific errors into a combined error and accumulate the successful results
+            val foundResults = keyPathReaders.foldLeft[(JsError, List[((JsPath, JsValue), Key)])]((JsError(), Nil)) {
+              case ((prevErrors, prevSuccesses), (path, format)) =>
+                val extractedKey = for {
+                  potentialKey <- path.asSingleJsResult(obj)
+                  foundKey <- format.reads(potentialKey)
+                } yield {
+                  (prevErrors, (path -> potentialKey, foundKey) :: prevSuccesses)
+                }
+                val allResults = extractedKey.recoverTotal { err =>
+                  (JsError.merge(err, prevErrors), prevSuccesses)
+                }
+                allResults
+            }
+            // Merge the final result from
+            val finalResult: JsResult[Key] = foundResults match {
+              case (allMergedPathErrors, Nil) =>
+                allMergedPathErrors
+              case (_, ((path, _), foundOneKey) :: Nil) =>
+                JsSuccess(foundOneKey, path)
+              case (_, foundMany) =>
+                val possibleKeys = foundMany.flatMap {
+                  case ((path, _), keyValue) =>
+                    JsError(path, s"Possible key: $keyValue").errors
+                }
+                JsError.merge(JsError(s"Found multiple possible keys for $valueType."), JsError(possibleKeys))
+            }
+            finalResult
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A set of functions that enables reading and writing a type key to Json for the purpose of serializing
+ * a trait or abstract class to and from json.
+ *
+ * In order to do this you need (1) a function that takes some model of the abstract type and returns a key,
+ * (2) a function that takes the key and returns a specific serializer for that model, and (3) a function
+ * to write the type key into the output json of each of the specific serializers.
+ *
+ * This class handles (1) and (3) and enables (2) by providing access to the key.
+ *
+ * In other words, this acts as a bi-directional binding between the key stored on the generic type [[T]]
+ * and the key stored in json. All that remains is to provide the function from key to specific serializer.
+ */
+@implicitNotFound(
+  "You must define an implicit TypeKeyExtractor[${T}] in scope.\n" +
+  "Try adding the following to the companion object of ${T}:\n" +
+  "implicit val extractor = Json.deriveTypeKey[${T}].usingKeyField(__ \\ \"keyPath\", _.keyField)")
+abstract class TypeKeyExtractor[T] private[ops] {
+
+  /**
+   * The runtime type of the key value after it is extracted from the [[JsValue]].
+   *
+   * This key is used by [[AbstractJsonOps.formatAbstract]] to find the right [[OFormat]] to
+   * use when parsing the Json as an abstract class or trait.
+   */
+  type Key
+
+  /**
+   * The [[TypeTag]] of the [[Key]]. Used for better error messages.
+   */
+  def keyTypeTag: TypeTag[Key]
+
+  /**
+   * The [[Type]] of [[Key]]. Used for better error messages.
+   *
+   * @note this is a val to force the evaluation of Type as early as possible since Scala's
+   *       reflection API is not thread-safe. Once this is resolved, it could be calculated
+   *       from the keyTypeTag in a lazy val.
+   */
+  val keyType: Type
+
+  /**
+   * The [[TypeTag]] of the value to [[Format]]. Used for better error messages.
+   */
+  def valueTypeTag: TypeTag[T]
+
+  /**
+   * The [[Type]] of the value to [[Format]]. Used for better error messages.
+   *
+   * @note this is a val to force the evaluation of Type as early as possible since Scala's
+   *       reflection API is not thread-safe. Once this is resolved, it could be calculated
+   *       from the keyTypeTag in a lazy val.
+   */
+  val valueType: Type
+
+  /**
+   * The [[JsPath]] to the key field.
+   *
+   * @note this only allows a single field to be used to determine the type. This was a
+   *       design choice to avoid too much complexity in serialization logic.
+   */
+  def keyPath: JsPath
+
+  /**
+   * Reads the key field off of the model object.
+    *
+    * @return the key used to look up the specific serializer
+   */
+  def readKeyFromModel(model: T): Key
+
+  /**
+   * Reads the key field off of the json.
+    *
+    * @return the key used to look up the specific serializer
+   */
+  def readKeyFromJson(json: JsValue): JsResult[Key]
+
+  /**
+   * Writes the key field to the output json.
+    *
+    * @return the json object to be combined with the output json
+   */
+  def writeKeyToJson(model: T): JsObject
+
+  /**
+   * Throws an [[UnrecognizedTypeKeyException]] exception with all the appropriate arguments.
+    *
+    * @param key the parsed key that has no corresponding [[OFormat]] for the specific
+   *            type associated with it
+   */
+  def throwUnrecognizedTypeKey(key: Any): Nothing = {
+    throw new UnrecognizedTypeKeyException(valueType, key, keyPath, keyType)
+  }
+}
+
+object TypeKeyExtractor {
+
+  /**
+    * Builds a [[TypeKeyExtractor]] from all the provided arguments.
+    *
+    * @see [[AbstractJsonOps.extractTypeKey]] for a more convenient syntax.
+    */
+  def apply[T, K](extractKey: T => K, pathToKey: JsPath = __)(
+    implicit formatKey: Format[K], tTag: TypeTag[T], kTag: TypeTag[K]): TypeKeyExtractor[T] = {
+    new TypeKeyExtractor[T] {
+      override type Key = K
+      override val keyPath: JsPath = pathToKey
+      override val keyTypeTag: TypeTag[Key] = kTag
+      override val keyType: Type = kTag.tpe
+      override val valueTypeTag: TypeTag[T] = tTag
+      override val valueType: Type = tTag.tpe
+      private val keyFormat: OFormat[K] = pathToKey.format(formatKey)
+      override def readKeyFromJson(json: JsValue): JsResult[Key] = keyFormat.reads(json)
+      override def writeKeyToJson(model: T): JsObject = {
+        val key = extractKey(model)
+        keyFormat.writes(key)
+      }
+      override def readKeyFromModel(model: T): Key = extractKey(model)
+    }
+  }
+
+  /**
+    * Builds a [[TypeKeyExtractor]] from all the provided arguments.
+    *
+    * @see [[AbstractJsonOps.extractTypeKey]] for a more convenient syntax.
+    */
+  def apply[T, K](extractKey: T => K, pathToKey: JsPath, readsKey: JsValue => JsResult[K], writesKey: K => JsValue)(
+    implicit tTag: TypeTag[T], kTag: TypeTag[K]): TypeKeyExtractor[T] = {
+    TypeKeyExtractor[T, K](extractKey, pathToKey)(Format(Reads(readsKey), Writes(writesKey)), tTag, kTag)
+  }
+
+  def of[T: TypeKeyExtractor]: TypeKeyExtractor[T] = implicitly
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/ClassNameUtils.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/ClassNameUtils.scala
@@ -1,0 +1,21 @@
+package play.api.libs.json.ops.v4
+
+private[v4] object ClassNameUtils {
+
+  /**
+   * Similar to the Class.getSimpleName method, except it does not throw any exceptions and
+   * handles Scala inner classes better.
+   */
+  def safeSimpleClassName(cls: Class[_]): String = {
+    // This logic is designed to be robust without much noise
+    // 1. use getName to avoid runtime exceptions from getSimpleName
+    // 2. filter out '$' anonymous class / method separators
+    // 3. start the full class name from the first upper-cased outer class name
+    //    (to avoid picking up unnecessary package names)
+    cls.getName
+      .split('.')
+      .last // safe because Class names will never be empty in any realistic scenario
+      .split('$')
+      .mkString(".")
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/Exceptions.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/Exceptions.scala
@@ -1,0 +1,128 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+import scala.reflect._
+import scala.reflect.runtime.universe._
+
+private[ops] object Exceptions {
+
+  /**
+    * Returns the estimated literal string of code you would use to match on this value.
+    */
+  def keyAsCodeLiteral(keyValue: Any): String = {
+    keyValue match {
+      case s: String => "\"%s\"".format(s) // for some reason string interpolation goes wonky here in Scala 2.11
+      case _ => keyValue.toString // this should work for most case classes and primitive types
+    }
+  }
+
+  /**
+    * Returns the path to the key in a more code-friendly format.
+    */
+  def keyPathAsString(keyPath: JsPath): String = {
+    val str = keyPath.toJsonString
+    if (str == "obj") "__" else str
+  }
+}
+
+/**
+  * An exception representing the failure to match a type key to the specific serializer
+  * for that type.
+  *
+  * @param valueType the type object of the generic type that could not be serialized
+  * @param keyValue the value of the key that was unmatched with a serializer
+  * @param keyPath the path to the key
+  * @param keyType the type object of the key
+  */
+class UnrecognizedTypeKeyException(
+  val valueType: Type,
+  val keyValue: Any,
+  val keyPath: JsPath,
+  val keyType: Type
+  ) extends RuntimeException({
+  val keyValueStr = Exceptions.keyAsCodeLiteral(keyValue)
+  val keyPathString = Exceptions.keyPathAsString(keyPath)
+  val keyPathWithType = s"$keyPathString.as[$keyType]"
+  s"Cannot parse instance of $valueType.\n" +
+    s"Unrecognized key '$keyValue' as extracted at path with type $keyPathWithType\n" +
+    "Please define the following in the Json.formatAbstract for this type:\n" +
+    s"  case $keyValueStr => OFormat.of[_ <: $valueType]\n"
+})
+
+/**
+  * Thrown when the type key cannot be deserialized from Json.
+  *
+  * @param valueType the type object of the generic type that could not be serialized
+  * @param jsonKey the key as written in Json
+  * @param readErrors the [[JsError]] values accumulated when parsing the type key
+  */
+class JsonTypeKeyReadException(
+  val valueType: Type,
+  val jsonKey: JsObject,
+  val readErrors: JsError
+) extends RuntimeException({
+  val jsonKeyString = Json.prettyPrint(jsonKey)
+  val readErrorsString = Json.prettyPrint(JsError.toJson(readErrors))
+  s"Cannot write an instance of $valueType.\n" +
+    s"The model's key was writen as Json: $jsonKeyString\n" +
+    s"but could not be converted into a type key because of the following validation errors: $readErrorsString\n" +
+    "Please make sure this object can be parsed by exactly one of the readers in the defined by:\n" +
+    s"  Json.extractTypeKeyOf[$valueType].usingKeyObject()\n"
+})
+
+/**
+  * Thrown when the wrong [[OFormat]] is chosen in the partial function given to [[AbstractJsonOps.formatAbstract]].
+  *
+  * @param valueType the type object of the generic type that could not be serialized
+  * @param keyValue the value of the key that was unmatched with a serializer
+  * @param keyPath the path to the key
+  * @param keyType the type object of the key
+  * @param cause the [[ClassCastException]] that caused this exception
+  */
+class WrongAbstractFormatException(
+  val valueType: Type,
+  val keyValue: Any,
+  val keyPath: JsPath,
+  val keyType: Type,
+  cause: ClassCastException
+) extends RuntimeException({
+  val keyPathString = Exceptions.keyPathAsString(keyPath)
+  val keyPathWithType = s"$keyPathString.as[$keyType]"
+  s"Cannot parse instance of $valueType.\n" +
+    s"The OFormat chosen by the given key '$keyValue' as extracted at path with type $keyPathWithType " +
+    "encountered a ClassCastException\n" +
+    "Please be sure that the definition of Json.formatAbstract uses the correct OFormat for this type.\n"
+}, cause)
+
+/**
+  * An exception that provides better error messaging than the standard [[JsResultException]].
+  *
+  * @note the constructor is private to prevent accidentally creating the exception without
+  *       applying the appropriate implicit transform.
+  * @param json the json that was being parsed (note, this is printed verbatim, be sure to redact
+  *             any sensitive information.
+  * @param error the [[JsError]] encountered while parsing the json
+  */
+class InvalidJsonException private[InvalidJsonException] (val expectedClass: Class[_], val json: JsValue, val error: JsError)
+  extends RuntimeException(
+    s"Could not read an instance of ${expectedClass.getName} from:\n" +
+      s"${Json.prettyPrint(json)}\n" +
+      s"Errors encountered:\n" +
+      s"${Json.prettyPrint(JsError.toJson(error))}"
+  )
+
+object InvalidJsonException {
+
+  /**
+    * Builds an instance of [[InvalidJsonException]] applying the appropriate [[JsonTransform]].
+    *
+    * @param rawJson the json that was being parsed (before applying the transform)
+    * @param error the [[JsError]] encountered while parsing the json
+    * @tparam A the type that was attempting to be parsed
+    */
+  def apply[A: JsonTransform: ClassTag](rawJson: JsValue, error: JsError): InvalidJsonException = {
+    val json = JsonTransform.transform(rawJson)
+    new InvalidJsonException(classTag[A].runtimeClass, json, error)
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/FormatKey.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/FormatKey.scala
@@ -1,0 +1,15 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.JsResult
+
+trait FormatKey[A] extends ReadsKey[A] with WritesKey[A]
+
+object FormatKey {
+
+  def of[A](implicit formatKey: FormatKey[A]): FormatKey[A] = formatKey
+
+  implicit def apply[A](implicit readsKey: ReadsKey[A], writesKey: WritesKey[A]): FormatKey[A] = new FormatKey[A] {
+    final override def write(key: A): String = writesKey.write(key)
+    final override def read(key: String): JsResult[A] = readsKey.read(key)
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsResults.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsResults.scala
@@ -1,0 +1,65 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.{JsError, JsPath, JsResult}
+
+/**
+  * Useful helper methods for combining and filtering [[JsResult]]s.
+  */
+object JsResults {
+
+  /**
+    * Filter out all [[JsError]]s and return a collection of results with the most specific type.
+    *
+    * @param results the results to filter
+    * @return a collection of results in whatever order the given collection type maintains
+    */
+  def ignoreErrors[T](results: Iterable[JsResult[T]]): Iterable[T] = {
+    results.filter(_.isSuccess).map(_.get)
+  }
+
+  /**
+    * Collects all [[JsError]]s and appends the index of result to path of the error.
+    *
+    * @param results a sequence of results
+    * @return a collection of the JsError objects in the sequence that they were given
+    */
+  def collectErrors(results: Iterable[JsResult[_]]): Iterable[JsError] = {
+    results.zipWithIndex.map {
+      case (result, index) => result.repath(JsPath(index))
+    }.collect {
+      case error: JsError => error
+    }
+  }
+
+  /**
+    * Groups all [[JsError.errors]] by key and concatenates errors with the same key.
+    *
+    * @see [[JsError.merge]]
+    * @param errors the errors to merge
+    * @return all the errors merged by key or None if the given errors are empty
+    */
+  def flattenErrors(errors: Iterable[JsError]): Option[JsError] = {
+    errors.reduceOption[JsError] {
+      case (e1, e2) => e1 ++ e2
+    }
+  }
+
+  /**
+    * Collects all [[JsError]]s and appends the index of the result to the path of the error,
+    * and then flattens all the errors into a single [[JsError]].
+    *
+    * This is effectively the same as:
+    * {{{
+    *   JsResults.flattenErrors(JsResults.collectErrors(results))
+    * }}}
+    *
+    * @note the paths of the results will never overlap, so the merge will never concatenate
+    *       errors from different indexes in the sequence of results
+    *
+    * @param results a sequence of [[JsResult]]s
+    * @return all the errors merged
+    */
+  def collectFlatError(results: Seq[JsResult[_]]): Option[JsError] = {
+    flattenErrors(collectErrors(results))
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsValueOps.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsValueOps.scala
@@ -1,0 +1,36 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Reads}
+
+import scala.reflect.ClassTag
+
+/**
+ * Provides helper methods on [[JsValue]].
+ *
+ * @param json the original json value
+ */
+class JsValueOps(val json: JsValue) extends AnyVal {
+
+  /**
+   * Attempts to parse the result as the provided type or throws a helpful exception message.
+   *
+   * @note Sometimes you may want to redact sensitive information from the json in the
+   *       exception message. To do this, just define an implicit JsonTransform for your
+   *       specific type, and it will apply the transformer before putting the original
+   *       json into the exception message.
+   */
+  def asOrThrow[A: Reads: ClassTag: JsonTransform]: A = json.validate[A] match {
+    case a: JsSuccess[A] => a.value
+    case err: JsError => throw InvalidJsonException[A](json, err)
+  }
+
+  /**
+   * Adds another way to call [[JsValue.transform]], but based on type using the implicit [[JsonTransform]].
+   *
+   * Uses the implicit [[JsonTransform]] for this type to redact or alter the resulting [[JsValue]].
+   *
+   * @tparam A the type of value to transform this json for
+   * @return a JsValue that has been altered based on the implicit transformer
+   */
+  def transformAs[A](implicit transformer: JsonTransform[A]): JsValue = transformer transform json
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsonImplicits.scala
@@ -1,0 +1,40 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+import scala.language.implicitConversions
+
+private[ops] class JsonImplicits private[ops] {
+
+  implicit def jsValueOps(json: JsValue): JsValueOps = new JsValueOps(json)
+
+  implicit def formatOps(format: Format.type): FormatOps.type = FormatOps
+
+  implicit def oformatOps(oformat: OFormat.type): OFormatOps.type = OFormatOps
+
+  implicit def abstractJsonOps(json: Json.type): AbstractJsonOps.type = AbstractJsonOps
+
+  implicit def abstractJsonOps(json: TypeKeyExtractor.type): AbstractJsonOps.type = AbstractJsonOps
+
+  implicit def readsMap[K: ReadsKey, V: Reads]: Reads[Map[K, V]] = {
+    val readsK = ReadsKey.of[K]
+    val stringKeyReader = Reads.map[V]
+    stringKeyReader.flatMap { a =>
+      Reads[Map[K, V]] { _ =>
+        val initResult: JsResult[Map[K, V]] = JsSuccess(Map())
+        a.map { case (k, v) => (readsK.read(k), v) }.foldLeft(initResult) {
+          case (JsSuccess(acc, _), (JsSuccess(k, _), v)) => JsSuccess(acc.updated(k, v))
+          case (JsSuccess(_, _), (firstError: JsError, _)) => firstError
+          case (accErrors: JsError, (errors: JsError, _)) => accErrors ++ errors
+          case (accErrors: JsError, _) => accErrors
+        }
+      }
+    }
+  }
+
+  implicit def owritesMap[K: WritesKey, V: Writes]: OWrites[Map[K, V]] = {
+    val writesK = WritesKey.of[K]
+    val stringKeyWriter = Writes.map[V]
+    OWrites[Map[K, V]](values => stringKeyWriter.writes(values.map { case (k, v) => (writesK.write(k), v) }))
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsonTransform.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/JsonTransform.scala
@@ -1,0 +1,61 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+import scala.reflect.ClassTag
+
+/**
+ * An implicit mechanism for transforming [[JsValue]]s before they are thrown in exceptions or printed
+ * to the logs.
+ *
+ * This is the ideal way to redact data from Json, when you know the starting type or expected type
+ * (in the case where you have failed to parse the model object and don't want to dump the json in
+ * the error message).
+ *
+ * @param transform a function that will add, remove, or modify fields.
+ * @tparam A a type-handle for selectively applying json transform functions.
+ */
+class JsonTransform[A](val transform: JsValue => JsValue) extends AnyVal
+
+object JsonTransform {
+
+  /**
+   * The default value to replace on redacted fields.
+   */
+  val RedactedValue: JsValue = JsString("[REDACTED]")
+
+  /**
+   * Provides a default transformer for all types.
+   *
+   * @return a transformer that will pass the json through unchanged
+   */
+  implicit def defaultTransform[A: ClassTag]: JsonTransform[A] = JsonTransform[A](identity[JsValue])
+
+  def apply[A](transform: JsValue => JsValue): JsonTransform[A] = new JsonTransform[A](transform)
+
+  def apply[A <: JsValue](implicit transform: Writes[JsValue]): JsonTransform[A] = new JsonTransform[A](transform.writes)
+
+  def obj[A](field: JsValue => JsValue = _.as[JsObject])(transform: JsObject => JsObject): JsonTransform[A] =
+    new JsonTransform[A]({
+      case o: JsObject => transform(o)
+      case v: JsValue  => field(v)
+    })
+
+  def redact[A](replace: JsValue => JsValue = _ => RedactedValue): JsonTransform[A] = {
+    JsonTransform.redactAll[A] {
+      case JsNull => JsNull
+      case defined: JsValue => replace(defined)
+    }
+  }
+
+  def redactAll[A](replace: JsValue => JsValue = _ => RedactedValue): JsonTransform[A] = JsonTransform(replace)
+
+  def redactPaths[A](paths: Seq[JsPath], replace: JsValue = RedactedValue): JsonTransform[A] = {
+    val redactedObj = JsPath.createObj(paths.map(_ -> replace): _*)
+    JsonTransform.obj() { o =>
+      o deepMerge redactedObj
+    }
+  }
+
+  def transform[A: JsonTransform](json: JsValue): JsValue = new JsValueOps(json).transformAs[A]
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/OFormatOps.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/OFormatOps.scala
@@ -1,0 +1,31 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+object OFormatOps extends OFormatPure {
+
+  def of[T: OFormat]: OFormat[T] = implicitly
+}
+
+trait OFormatPure {
+
+  /**
+   * Creates a Format that always reads the given value (regardless of the input)
+   * and writes the given JsValue (regardless of the value given).
+   *
+   * @param value the pure value to always read.
+   */
+  def pure[T](value: => T)(implicit writer: OWrites[T]): OFormat[T] = pure[T](value, writer.writes(value))
+
+  /**
+   * Creates a Format that always reads the given value (regardless of the input)
+   * and writes the given JsValue (regardless of the value given).
+   *
+   * @param value the pure value to always read.
+   * @param json the pure json to always write.
+   */
+  def pure[T](value: => T, json: => JsObject): OFormat[T] = new OFormat[T] {
+    override def reads(json: JsValue): JsResult[T] = JsSuccess(value)
+    override def writes(o: T): JsObject = json
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/PlayJsonMacros.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/PlayJsonMacros.scala
@@ -1,0 +1,345 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.{Json, Reads}
+
+import scala.collection.Factory
+import scala.language.experimental.macros
+import scala.language.reflectiveCalls
+import scala.reflect.macros.whitebox
+
+/**
+ * Provides macros similar to those in [[Json]] but with modified functionality to better handle our common json
+ * parsing use cases, for example missing fields (instead of empty arrays).
+ */
+object PlayJsonMacros extends TolerantContainerFormats {
+
+  /**
+   * Same as [[Json.reads]] but when reading containers such as [[List]], [[Seq]], [[Set]], etc., if the field
+   * is missing will return an empty container instead of failing to validate the model.
+   *
+   * NOTE: this doesn't seem to work with Array, but does work with [[scala.collection.mutable.ArraySeq]] and
+   *       other collections which extend [[Traversable]]
+   *
+   * @see [[TolerantContainerPath.readNullableContainer]]
+   * @tparam A The model you're generating a [[Reads]] for
+   * @return a [[Reads]] that will deserialize [[A]], with empty containers for fields that are missing from the json.
+   */
+  def nullableReads[A]: Reads[A] = macro nullableReadsImpl[A]
+
+  /**
+   * copied from [[play.api.libs.json.JsMacroImpl.readsImpl]] implementation and modified to use the readNullableContainer helper
+   * @see https://github.com/playframework/playframework/blob/2.3.x/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala#L11
+   */
+  def nullableReadsImpl[A: c.WeakTypeTag](c: whitebox.Context): c.Expr[Reads[A]] = {
+    import c.universe.Flag._
+    import c.universe._
+
+    val companioned = weakTypeOf[A].typeSymbol
+    val companionSymbol = companioned.companion
+    val companionType = companionSymbol.typeSignature
+
+    val libsPkg = Select(Select(Ident(TermName("play")), TermName("api")), TermName("libs"))
+    val jsonPkg = Select(libsPkg, TermName("json"))
+    val functionalSyntaxPkg = Select(Select(libsPkg, TermName("functional")), TermName("syntax"))
+    val utilPkg = Select(jsonPkg, TermName("util"))
+
+    val jsPathSelect = Select(jsonPkg, TermName("JsPath"))
+    val readsSelect = Select(jsonPkg, TermName("Reads"))
+    val lazyHelperSelect = Select(utilPkg, TypeName("LazyHelper"))
+
+    val importFunctionalSyntax = Import(functionalSyntaxPkg, List(ImportSelector(termNames.WILDCARD, -1, null, -1)))
+
+    companionType.decl(TermName("unapply")) match {
+      case NoSymbol => c.abort(c.enclosingPosition, "No unapply function found")
+      case s =>
+        val unapply = s.asMethod
+        val unapplyReturnTypes = unapply.returnType match {
+          case TypeRef(_, _, Nil) =>
+            c.abort(c.enclosingPosition, s"Apply of ${companionSymbol} has no parameters. Are you using an empty case class?")
+          case TypeRef(_, _, args) =>
+            args.head match {
+              case t @ TypeRef(_, _, Nil) => Some(List(t))
+              case t @ TypeRef(_, _, args) =>
+                if (t <:< typeOf[Option[_]]) Some(List(t))
+                else if (t <:< typeOf[Seq[_]]) Some(List(t))
+                else if (t <:< typeOf[Set[_]]) Some(List(t))
+                else if (t <:< typeOf[Map[_, _]]) Some(List(t))
+                else if (t <:< typeOf[Product]) Some(args)
+              case _ => None
+            }
+          case _ => None
+        }
+
+        companionType.decl(TermName("apply")) match {
+          case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
+          case s =>
+            // searches apply method corresponding to unapply
+            val applies = s.asMethod.alternatives
+            val apply = applies.collectFirst {
+              case apply: MethodSymbol
+                if apply.paramLists.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes => apply
+            }
+            apply match {
+              case Some(apply) =>
+                val params = apply.paramLists.head // verify there is a single parameter group
+
+                val inferedImplicits = params.map(_.typeSignature).map { implType =>
+
+                  // innerType is only used if we're working with a container and using readNullableContainer below
+                  val (isRecursive, tpe, innerType) = implType match {
+                    case TypeRef(_, _, args) =>
+                      // Option[_] needs special treatment because we need to use XXXOpt
+                      if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                        (args.exists(_.typeSymbol == companioned), args.head, args.head)
+                      else if (implType.typeConstructor <:< typeOf[Iterable[_]].typeConstructor)
+                        (args.exists(_.typeSymbol == companioned), implType, args.head)
+                      else
+                        (args.exists(_.typeSymbol == companioned), implType, implType)
+                    case _ =>
+                      (false, implType, implType)
+                  }
+
+                  // builds reads implicit from expected type
+                  val neededReadsImplicitType = appliedType(weakTypeOf[Reads[_]].typeConstructor, tpe :: Nil)
+                  // infers implicit
+                  val neededReadsImplicit = c.inferImplicitValue(neededReadsImplicitType)
+
+                  // summons implicit Factory if type is Iterable
+                  val neededFactoryImplicit = if (tpe != innerType) {
+                    val neededFactoryImplicitType =
+                      appliedType(weakTypeOf[Factory[_, _]].typeConstructor, List(innerType, tpe))
+                    c.inferImplicitValue(neededFactoryImplicitType)
+                  } else
+                    neededReadsImplicit
+
+                  (implType, neededReadsImplicit, neededFactoryImplicit, isRecursive, tpe, innerType)
+                }
+
+                // if any implicit is missing, abort
+                // else goes on
+                inferedImplicits.collect {
+                  case (t, readsImplicit, _, rec, _, _) if readsImplicit == EmptyTree && !rec => t
+                } match {
+                  case List() =>
+                    val namedImplicits = params.map(_.name).zip(inferedImplicits)
+
+                    val helperMember = Select(This(typeNames.EMPTY), TermName("lazyStuff"))
+
+                    var hasRec = false
+
+                    // combines all reads into CanBuildX
+                    val canBuild = namedImplicits.map {
+                      case (name, (t, readsImplicit, bfImplicit, rec, tpe, innerType)) =>
+                        // inception of (__ \ name).read(readsImplicit)
+                        val jspathTree = Apply(
+                          Select(jsPathSelect, TermName(scala.reflect.NameTransformer.encode("\\"))),
+                          List(Literal(Constant(name.decodedName.toString)))
+                        )
+
+                        if (!rec) {
+                          val readTree =
+                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                              Apply(
+                                Select(jspathTree, TermName("readNullable")),
+                                List(readsImplicit)
+                              )
+                            // If Traversable, then apply readNullableContainer helper instead
+                            else if (t.typeConstructor <:< typeOf[Iterable[_]].typeConstructor) {
+                              val justContainer = tpe.typeConstructor
+                              val app = Apply(
+                                c.Expr[Any](
+                                  q"${Select(jspathTree, TermName("readNullableContainer"))}[$justContainer,$innerType]"
+                                ).tree,
+                                List(readsImplicit, bfImplicit)
+                              )
+                              app
+                            } else Apply(
+                              Select(jspathTree, TermName("read")),
+                              List(readsImplicit)
+                            )
+
+                          readTree
+                        } else {
+                          hasRec = true
+                          val readTree =
+                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                              Apply(
+                                Select(jspathTree, TermName("readNullable")),
+                                List(
+                                  Apply(
+                                    Select(Apply(jsPathSelect, List()), TermName("lazyRead")),
+                                    List(helperMember)
+                                  )
+                                )
+                              )
+                            // If Traversable, then apply readNullableContainer helper instead
+                            else if (t.typeConstructor <:< typeOf[Iterable[_]].typeConstructor)
+                              Apply(
+                                Select(jspathTree, TermName("readNullableContainer")),
+                                if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("list")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("set")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("seq")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("map")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else List(helperMember)
+                              )
+
+                            else {
+                              Apply(
+                                Select(jspathTree, TermName("lazyRead")),
+                                if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("list")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("set")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("seq")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+                                  List(
+                                    Apply(
+                                      Select(readsSelect, TermName("map")),
+                                      List(helperMember)
+                                    )
+                                  )
+                                else List(helperMember)
+                              )
+                            }
+
+                          readTree
+                        }
+                    }.reduceLeft { (acc, r) =>
+                      Apply(
+                        Select(acc, TermName("and")),
+                        List(r)
+                      )
+                    }
+
+                    // builds the final Reads using apply method
+                    val applyMethod =
+                      Function(
+                        params.foldLeft(List[ValDef]())((l, e) =>
+                          l :+ ValDef(Modifiers(PARAM), TermName(e.name.encodedName.toString), TypeTree(), EmptyTree)
+                        ),
+                        Apply(
+                          Select(Ident(companionSymbol.name), TermName("apply")),
+                          params.foldLeft(List[Tree]())((l, e) =>
+                            l :+ Ident(TermName(e.name.encodedName.toString))
+                          )
+                        )
+                      )
+
+                    // if case class has one single field, needs to use inmap instead of canbuild.apply
+                    val finalTree = if (params.length > 1) {
+                      Apply(
+                        Select(canBuild, TermName("apply")),
+                        List(applyMethod)
+                      )
+                    } else {
+                      Apply(
+                        Select(canBuild, TermName("map")),
+                        List(applyMethod)
+                      )
+                    }
+
+                    if (!hasRec) {
+                      c.Expr[Reads[A]](
+                        q"""{
+                          $importFunctionalSyntax
+                          $finalTree
+                        }"""
+                      )
+                    } else {
+                      val defineClassWithLazyStuff = ClassDef(
+                        Modifiers(Flag.FINAL),
+                        TypeName("$anon"),
+                        List(),
+                        Template(
+                          List(
+                            AppliedTypeTree(
+                              lazyHelperSelect,
+                              List(
+                                Ident(weakTypeOf[Reads[A]].typeSymbol),
+                                Ident(weakTypeOf[A].typeSymbol)
+                              )
+                            )
+                          ),
+                          noSelfType,
+                          List(
+                            DefDef(
+                              Modifiers(),
+                              termNames.CONSTRUCTOR,
+                              List(),
+                              List(List()),
+                              TypeTree(),
+                              Apply(
+                                Select(Super(This(typeNames.EMPTY), typeNames.EMPTY), termNames.CONSTRUCTOR),
+                                List()
+                              )
+                            ),
+                            ValDef(
+                              Modifiers(Flag.OVERRIDE | Flag.LAZY),
+                              TermName("lazyStuff"),
+                              AppliedTypeTree(Ident(weakTypeOf[Reads[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
+                              finalTree
+                            )
+                          )
+                        )
+                      )
+                      val constructInstance = Apply(Select(New(Ident(TypeName("$anon"))), termNames.CONSTRUCTOR), List())
+                      val lazyStuff = TermName("lazyStuff")
+
+                      c.Expr[Reads[A]](
+                        q"""{
+                          $importFunctionalSyntax
+                          $defineClassWithLazyStuff
+                          $constructInstance
+                        }.$lazyStuff"""
+                      )
+                    }
+                  case l => c.abort(c.enclosingPosition, s"No implicit Reads for ${l.mkString(", ")} available.")
+                }
+
+              case None => c.abort(c.enclosingPosition, "No apply function found matching unapply return types")
+            }
+
+        }
+    }
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/ReadsKey.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/ReadsKey.scala
@@ -1,0 +1,67 @@
+package play.api.libs.json.ops.v4
+
+import java.util.UUID
+
+import play.api.libs.json.{JsError, JsResult, JsSuccess}
+
+trait ReadsKey[A] { self =>
+
+  /**
+    * Read the string value into a typed key or return ignore this invalid key None.
+    */
+  def read(key: String): JsResult[A]
+
+  final def map[B](f: A => B): ReadsKey[B] = new ReadsKey[B] {
+    final override def read(key: String): JsResult[B] = self.read(key).map(f)
+  }
+
+  final def flatMap[B](f: A => ReadsKey[B]): ReadsKey[B] = new ReadsKey[B] {
+    final override def read(key: String): JsResult[B] = self.read(key).flatMap(a => f(a).read(key))
+  }
+}
+
+object ReadsKey {
+
+  def of[A](implicit readsKey: ReadsKey[A]): ReadsKey[A] = readsKey
+
+  def apply[A](fn: String => JsResult[A]): ReadsKey[A] = new ReadsKey[A] {
+    override def read(key: String): JsResult[A] = fn(key)
+  }
+
+  private[this] def readsKeyNumber[A](f: String => A): ReadsKey[A] = new ReadsKey[A] {
+    final def read(key: String): JsResult[A] = try JsSuccess(f(key)) catch {
+      case ex: NumberFormatException => JsError(ex.getMessage)
+    }
+  }
+
+  /**
+    * A [[ReadsKey]] that will always succeed.
+    */
+  private[ops] abstract class AlwaysReadsKey[A] extends ReadsKey[A] {
+    def readSafe(key: String): A
+    final override def read(key: String): JsResult[A] = JsSuccess(readSafe(key))
+  }
+
+  implicit val readKeyString: ReadsKey[String] = new AlwaysReadsKey[String] {
+    final override def readSafe(key: String): String = key
+  }
+
+  implicit val readKeySymbol: ReadsKey[Symbol] = new AlwaysReadsKey[Symbol] {
+    final override def readSafe(key: String): Symbol = Symbol(key)
+  }
+
+  implicit val readKeyUUID: ReadsKey[UUID] = new ReadsKey[UUID] {
+    final override def read(key: String): JsResult[UUID] = {
+      if (key.length == 36) {
+        try JsSuccess(UUID.fromString(key)) catch {
+          case _: IllegalArgumentException => JsError("Invalid UUID format")
+        }
+      } else JsError("Invalid UUID length")
+    }
+  }
+
+  implicit val readKeyByte: ReadsKey[Byte] = readsKeyNumber(java.lang.Byte.parseByte)
+  implicit val readKeyShort: ReadsKey[Short] = readsKeyNumber(java.lang.Short.parseShort)
+  implicit val readKeyInt: ReadsKey[Int] = readsKeyNumber(java.lang.Integer.parseInt)
+  implicit val readKeyLong: ReadsKey[Long] = readsKeyNumber(java.lang.Long.parseLong)
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/TolerantContainerFormats.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/TolerantContainerFormats.scala
@@ -1,0 +1,25 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.{JsPath, Reads}
+
+import scala.collection.{BuildFrom, Factory}
+import scala.language.{higherKinds, implicitConversions}
+
+/**
+ * Provides helpers which will create empty containers if a json field is missing
+ *
+ * @see [[play.api.libs.json.ops.TolerantContainerPath.readNullableContainer]]
+ */
+trait TolerantContainerFormats {
+  implicit final def getTolerantContainerPath(jsPath: JsPath): TolerantContainerPath = new TolerantContainerPath(jsPath)
+}
+
+class TolerantContainerPath(val jsPath: JsPath) extends AnyVal {
+
+  /**
+   * Defines a [[Reads]] that will read all container fields such that `null=[]` (or an empty [[Set]] / [[Map]])
+   */
+  def readNullableContainer[C[_], A](implicit r: Reads[C[A]], f: Factory[A, C[A]]): Reads[C[A]] = {
+    Reads.nullable[C[A]](jsPath)(r).map(_.getOrElse(f.newBuilder.result()))
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/WritesKey.scala
+++ b/play-json-ops-common-213/src/main/scala/play/api/libs/json/ops/v4/WritesKey.scala
@@ -1,0 +1,52 @@
+package play.api.libs.json.ops.v4
+
+import java.util.UUID
+
+trait WritesKey[A] { self =>
+
+  /**
+    * Write the given key value as a string.
+    */
+  def write(key: A): String
+
+  final def contramap[B](f: B => A): WritesKey[B] = new WritesKey[B] {
+    final override def write(key: B): String = self.write(f(key))
+  }
+}
+
+object WritesKey {
+
+  def of[A](implicit writesKey: WritesKey[A]): WritesKey[A] = writesKey
+
+  def apply[A](fn: A => String): WritesKey[A] = new WritesKey[A] {
+    final override def write(key: A): String = fn(key)
+  }
+  
+  implicit val writesKeyString: WritesKey[String] = new WritesKey[String] {
+    final override def write(key: String): String = key
+  }
+
+  implicit val writesKeySymbol: WritesKey[Symbol] = new WritesKey[Symbol] {
+    final override def write(key: Symbol): String = key.name
+  }
+
+  implicit val writesKeyUUID: WritesKey[UUID] = new WritesKey[UUID] {
+    final override def write(key: UUID): String = key.toString
+  }
+
+  implicit val writesKeyByte: WritesKey[Byte] = new WritesKey[Byte] {
+    final override def write(key: Byte): String = java.lang.Byte.toString(key)
+  }
+
+  implicit val writesKeyShort: WritesKey[Short] = new WritesKey[Short] {
+    final override def write(key: Short): String = java.lang.Short.toString(key)
+  }
+
+  implicit val writesKeyInt: WritesKey[Int] = new WritesKey[Int] {
+    final override def write(key: Int): String = java.lang.Integer.toString(key)
+  }
+
+  implicit val writesKeyLong: WritesKey[Long] = new WritesKey[Long] {
+    final override def write(key: Long): String = java.lang.Long.toString(key)
+  }
+}

--- a/play-json-ops-common-213/src/main/scala/scala/concurrent/duration/ops/v4/DurationOps.scala
+++ b/play-json-ops-common-213/src/main/scala/scala/concurrent/duration/ops/v4/DurationOps.scala
@@ -1,0 +1,134 @@
+package scala.concurrent.duration.ops.v4
+
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Provides useful operations on generic [[Duration]]s.
+ */
+object DurationOps {
+
+  /**
+   * This duplicates the logic from [[Duration.apply(s: String)]] but does not give up any precision.
+   *
+   * @note calling [[Duration.toString]] on x should always yield Some(x) with the same length and duration.
+   *
+   * @param durationString a string to parse a [[Duration]] from (typically from Duration.toString)
+   * @return the first [[Duration]] value parsed from a given string
+   */
+  def parseLossless(durationString: String): Try[Duration] = {
+    durationString.dropWhile(_.isWhitespace).toLowerCase match {
+      case "inf" | "plusinf" | "+inf" => Success(Duration.Inf)
+      case "minusinf" | "-inf"        => Success(Duration.MinusInf)
+      case "undefined"                => Success(Duration.Undefined)
+      case trimmed =>
+        Try {
+          trimmed.takeWhile {
+            case '-' | '+' => true
+            case x if x.isDigit => true
+            case _ => false
+          }.toLong
+        } flatMap { len =>
+          parseUnit(trimmed) match {
+            case Some(unit) => Success(Duration(len, unit))
+            case None =>
+              Failure(new NumberFormatException(s"missing unit from duration '$durationString'"))
+          }
+        }
+    }
+  }
+
+  /**
+   * This duplicates the logic from [[Duration.apply(s: String)]] but only parses the unit.
+   *
+   * Grabs the first [[TimeUnit]] from a string, but only compares whole words as separated
+   * by whitespace, numbers, or punctuation.
+   *
+   * @note calling [[FiniteDuration.toString]] on x should always return a Some(x.unit)
+   *
+   * @param durationString a string to parse a [[TimeUnit]] from (typically from Duration.toString)
+   * @return the first [[TimeUnit]] value parsed from a given string
+   */
+  def parseUnit(durationString: String): Option[TimeUnit] = {
+    val trimmed: String = durationString dropWhile (!_.isLetter)
+    val unitName = trimmed takeWhile (_.isLetter)
+    timeUnit get unitName
+  }
+
+  // "ms milli millisecond" -> List("ms", "milli", "millis", "millisecond", "milliseconds")
+  private[this] def words(s: String) = (s.trim split "\\s+").toList
+  private[this] def expandLabels(labels: String): List[String] = {
+    val hd :: rest = words(labels)
+    hd :: rest.flatMap(s => List(s, s + "s"))
+  }
+  private[this] val timeUnitLabels = List(
+    DAYS         -> "d day",
+    HOURS        -> "h hour",
+    MINUTES      -> "min minute",
+    SECONDS      -> "s sec second",
+    MILLISECONDS -> "ms milli millisecond",
+    MICROSECONDS -> "µs micro microsecond",
+    NANOSECONDS  -> "ns nano nanosecond"
+  )
+
+  private[this] val timeUnit: Map[String, TimeUnit] =
+    timeUnitLabels.flatMap { case (unit, names) => expandLabels(names) map (_ -> unit) }.toMap
+}
+
+/**
+ * Provides useful operations on [[FiniteDuration]]s.
+ */
+object FiniteDurationOps {
+
+  /**
+   * Same as [[Duration.toUnit]] except avoids loss of precision by not converting to Double first.
+   *
+   * @param duration the duration to convert
+   * @param unit the [[TimeUnit]] to convert it to
+   */
+  def convertToUnitPrecisely(duration: FiniteDuration, unit: TimeUnit): FiniteDuration = {
+    val magnitude = unit match {
+      case DAYS         => duration.toDays
+      case HOURS        => duration.toHours
+      case MICROSECONDS => duration.toMicros
+      case MILLISECONDS => duration.toMillis
+      case MINUTES      => duration.toMinutes
+      case NANOSECONDS  => duration.toNanos
+      case SECONDS      => duration.toSeconds
+    }
+    Duration(magnitude, unit)
+  }
+}
+
+/**
+ * Provides additional operations on [[FiniteDuration]] with no runtime allocation overhead.
+ */
+class FiniteDurationOps(val duration: FiniteDuration) extends AnyVal {
+
+  /**
+   * Drops any extra precision that would be unrepresentable in the current Duration's [[TimeUnit]].
+   */
+  def dropInsignificantDigits: FiniteDuration = toUnitPrecise(duration.unit)
+
+  /**
+   * Converts a [[FiniteDuration]] to the provided unit without any loss of precision.
+   *
+   * @note this method has no affect on [[Duration.Infinite]] values
+   *
+   * @param unit the [[TimeUnit]], such as [[DAYS]], [[HOURS]], etc
+   * @return a new [[FiniteDuration]] with the provided unit or the given [[Duration.Infinite]]
+   */
+  def toUnitPrecise(unit: TimeUnit): FiniteDuration = FiniteDurationOps.convertToUnitPrecisely(duration, unit)
+}
+
+/**
+ * Extend this trait to get additional operations on [[FiniteDuration]]s.
+ *
+ * These are also made available by adding `import scala.concurrent.duration.ops._`
+ */
+trait DurationImplicits {
+
+  implicit def fromFiniteDuration(duration: FiniteDuration): FiniteDurationOps =
+    new FiniteDurationOps(duration)
+}

--- a/play-json-ops-common-213/src/main/scala/scala/concurrent/duration/ops/v4/package.scala
+++ b/play-json-ops-common-213/src/main/scala/scala/concurrent/duration/ops/v4/package.scala
@@ -1,0 +1,3 @@
+package scala.concurrent.duration.ops
+
+package object v4 extends DurationImplicits

--- a/play-json-ops-common/src/main/scala/play/api/libs/json/ops/v4/ClassNameUtils.scala
+++ b/play-json-ops-common/src/main/scala/play/api/libs/json/ops/v4/ClassNameUtils.scala
@@ -1,0 +1,21 @@
+package play.api.libs.json.ops.v4
+
+private[v4] object ClassNameUtils {
+
+  /**
+   * Similar to the Class.getSimpleName method, except it does not throw any exceptions and
+   * handles Scala inner classes better.
+   */
+  def safeSimpleClassName(cls: Class[_]): String = {
+    // This logic is designed to be robust without much noise
+    // 1. use getName to avoid runtime exceptions from getSimpleName
+    // 2. filter out '$' anonymous class / method separators
+    // 3. start the full class name from the first upper-cased outer class name
+    //    (to avoid picking up unnecessary package names)
+    cls.getName
+      .split('.')
+      .last // safe because Class names will never be empty in any realistic scenario
+      .split('$')
+      .mkString(".")
+  }
+}

--- a/play27-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/PlayJsonFormatSpecExample.scala
+++ b/play27-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/PlayJsonFormatSpecExample.scala
@@ -11,8 +11,6 @@ import play.api.libs.json.{Json, OFormat}
 import play.api.libs.json.scalacheck.PlayJsonFormatFlatSpecExample.SampleException
 import play.api.libs.json.scalatest.PlayJsonFormatSpec
 
-import scala.language.implicitConversions
-
 case class Example(value: String, nested: Seq[Example])
 
 object Example {
@@ -104,7 +102,7 @@ with ScalaCheckDrivenPropertyChecks {
   }
 
   "PlayJsonFormatFlatSpecExample.shrink" should "use the implicit shrink" in {
-    val example = Arbitrary.arbitrary[Example].suchThat(_.nested.nonEmpty).getOrThrow
+    val example = genExample(1).randomOrThrow()
     val ex = intercept[TestFailedException] {
       val expected = example.copy(nested = Seq())
       assertSameWithShrink(expected, example, Json.toJson(example))

--- a/play28-json-ops/src/main/scala/play/api/libs/json/ops/v4/RecoverOps.scala
+++ b/play28-json-ops/src/main/scala/play/api/libs/json/ops/v4/RecoverOps.scala
@@ -1,0 +1,97 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json._
+
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+sealed trait RecoverOps[F[x] <: Reads[x], A] extends Any {
+
+  def unsafeReader: Reads[A]
+
+  /**
+   * Recovers from all exceptions thrown during reading, producing an exception-safe Reads.
+   */
+  def recoverTotal(recoverFn: Throwable => A): Reads[A] = build { json =>
+    try {
+      unsafeReader.reads(json)
+    } catch {
+      case NonFatal(ex) => JsSuccess(recoverFn(ex))
+    }
+  }
+
+  /**
+   * Translates exceptions thrown during reading into JsError validation results.
+   */
+  def recoverJsError(implicit ct: ClassTag[A]): Reads[A] = {
+    recoverWith {
+      case ex => RecoverOps.expectedTypeError(ct.runtimeClass, ex)
+    }
+  }
+
+  /**
+   * Recovers from some exceptions thrown during reading into a [[JsResult]].
+   *
+   * @note if the recover function is undefined for an exception, the [[Reads]] produced is still unsafe.
+   */
+  def recoverWith(
+    recoverFn: PartialFunction[Throwable, JsResult[A]]
+  ): Reads[A] = build { json =>
+    try {
+      unsafeReader.reads(json)
+    } catch {
+      case NonFatal(ex) if recoverFn isDefinedAt ex => recoverFn(ex)
+    }
+  }
+
+  // Subclasses need to define how to build an instance of F[A] from a Reads[A]
+  protected def build(safeReader: Reads[A]): F[A]
+}
+
+object RecoverOps {
+
+  /**
+   * Similar to the Class.getSimpleName method, except it does not throw any exceptions and
+   * handles Scala inner classes better.
+   */
+  private def safeSimpleClassName(cls: Class[_]): String = {
+    ClassNameUtils.safeSimpleClassName(cls)
+  }
+
+  /**
+   * Following the style of play json's DefaultReads class. Type should be all lowercase.
+   *
+   * @note this method is not cross-compatible between Play 2.5 and above. Once everything
+   *       uses [[JsonValidationError]], we can move this whole file to the common project.
+   *
+   * e.g.
+   * error.expected.string
+   * error.expected.uuid
+   */
+  private def expectedTypeError(tpe: String, args: Any*): JsError = {
+    val className = tpe.toLowerCase
+    JsError(JsonValidationError(s"error.expected.$className", args: _*))
+  }
+
+  /**
+   * Same as [[expectedTypeError]], except safely converts the class to a string.
+   */
+  private def expectedTypeError(cls: Class[_], args: Any*): JsError = {
+    expectedTypeError(safeSimpleClassName(cls), args: _*)
+  }
+}
+
+final class ReadsRecoverOps[A](override val unsafeReader: Reads[A]) extends AnyVal with RecoverOps[Reads, A] {
+  override protected def build(safeReader: Reads[A]): Reads[A] = safeReader
+}
+
+final class FormatRecoverOps[A](val unsafeFormat: Format[A]) extends AnyVal with RecoverOps[Format, A] {
+  override def unsafeReader: Reads[A] = unsafeFormat
+  override protected def build(safeReader: Reads[A]): Format[A] = Format(safeReader, unsafeFormat)
+}
+
+final class OFormatRecoverOps[A](val unsafeFormat: OFormat[A]) extends AnyVal with RecoverOps[OFormat, A] {
+  override def unsafeReader: Reads[A] = unsafeFormat
+  override protected def build(safeReader: Reads[A]): OFormat[A] = OFormat(safeReader, unsafeFormat)
+}

--- a/play28-json-ops/src/main/scala/play/api/libs/json/ops/v4/package.scala
+++ b/play28-json-ops/src/main/scala/play/api/libs/json/ops/v4/package.scala
@@ -1,0 +1,14 @@
+package play.api.libs.json.ops
+
+import play.api.libs.json.{Format, OFormat, Reads}
+
+import scala.language.implicitConversions
+
+package object v4 extends JsonImplicits {
+
+  implicit def safeReadsOps[A](reads: Reads[A]): ReadsRecoverOps[A] = new ReadsRecoverOps(reads)
+
+  implicit def safeFormatOps[A](format: Format[A]): FormatRecoverOps[A] = new FormatRecoverOps(format)
+
+  implicit def safeOFormatOps[A](oformat: OFormat[A]): OFormatRecoverOps[A] = new OFormatRecoverOps(oformat)
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Counted.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Counted.scala
@@ -1,0 +1,26 @@
+package play.api.libs.json.scalacheck
+
+trait Counted extends Any {
+
+  def count: Int
+
+  protected def throwOnNegative(): Nothing
+
+  def validate(): Unit = {
+    count match {
+      case neg if neg < 0 => throwOnNegative()
+      case pos =>
+    }
+  }
+
+  def <(that: Int) = this.count < that
+
+  def <=(that: Int) = this.count <= that
+
+  def >(that: Int) = this.count > that
+
+  def >=(that: Int) = this.count >= that
+
+  def ===(that: Int) = this.count == that
+
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Depth.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Depth.scala
@@ -1,0 +1,23 @@
+package play.api.libs.json.scalacheck
+
+import scala.language.implicitConversions
+
+class Depth private[Depth] (val depth: Int) extends AnyVal with Counted {
+  override protected def throwOnNegative(): Nothing = throw new IllegalArgumentException("Depth cannot be negative")
+  @inline override def count: Int = depth
+  def -(that: Depth) = Depth(this.depth - that.depth)
+  def +(that: Depth) = new Depth(this.depth + that.depth)  // no need to validate
+}
+
+object Depth extends (Int => Depth) {
+
+  implicit def fromInt(int: Int): Depth = Depth(int)
+
+  implicit def toInt(depth: Depth): Int = depth.depth
+
+  override def apply(depth: Int): Depth = {
+    val d = new Depth(depth)
+    d.validate()
+    d
+  }
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/DurationGenerators.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/DurationGenerators.scala
@@ -1,0 +1,53 @@
+package play.api.libs.json.scalacheck
+
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.concurrent.duration._
+import scala.concurrent.duration.ops.v4._
+import scala.language.implicitConversions
+
+trait DurationGenerators {
+
+  implicit val arbTimeUnit: Arbitrary[TimeUnit] = Arbitrary {
+    Gen.oneOf(
+      DAYS,
+      HOURS,
+      MICROSECONDS,
+      MILLISECONDS,
+      MINUTES,
+      NANOSECONDS,
+      SECONDS
+    )
+  }
+
+  /**
+   * [[Duration]] doesn't support unsigned operations to allow unary - to be symmetric
+   */
+  private val minNanos = Long.MinValue + 1
+  private val maxNanos = Long.MaxValue
+
+  implicit def arbFiniteDuration(implicit timeUnitArb: Arbitrary[TimeUnit]): Arbitrary[FiniteDuration] = Arbitrary {
+    for {
+      length <- Gen.chooseNum(minNanos, maxNanos)
+      unit <- timeUnitArb.arbitrary
+    } yield Duration(length, NANOSECONDS).toUnitPrecise(unit)
+  }
+
+  implicit def arbDuration(implicit timeUnitArb: Arbitrary[TimeUnit]): Arbitrary[Duration] = Arbitrary {
+    for {
+      length <- Gen.oneOf(
+        Gen.chooseNum(minNanos, maxNanos),
+        Gen.oneOf(Double.NegativeInfinity, Double.MinPositiveValue, Double.PositiveInfinity, Double.NaN)
+      )
+      unit <- timeUnitArb.arbitrary
+    } yield length match {
+      case nanos: Long =>
+        Duration(nanos, NANOSECONDS).toUnitPrecise(unit)
+      case inf: Double =>
+        Duration(inf, NANOSECONDS)
+    }
+  }
+
+}
+
+object DurationGenerators extends DurationGenerators

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/JsValueGenerators.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/JsValueGenerators.scala
@@ -1,0 +1,163 @@
+package play.api.libs.json.scalacheck
+
+import java.math.MathContext
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen._
+import org.scalacheck.Shrink._
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import play.api.libs.json._
+
+import scala.language.implicitConversions
+
+trait JsValueGenerators {
+
+  /**
+   * The maximum number of fields of a [[JsObject]] or elements of a [[JsArray]] to construct when
+   * generating one of these nested [[JsValue]]s.
+   */
+  def defaultMaxWidth: Width = Width(2)
+
+  /**
+   * The maximum number of levels deep where nested values ([[JsObject]]s or [[JsArray]]s) can be generated.
+   *
+   * In other words:
+   * - A depth of 0 generates only primitive [[JsValue]]s
+   * - A depth of 1 generates any type of [[JsValue]] where all nested values contain only primitive [[JsValue]]s.
+   * - A depth of n generates any type of [[JsValue]] where all nested values contain [[JsValue]]s with a depth of n - 1
+   */
+  def defaultMaxDepth: Depth = Depth(2)
+
+  implicit def arbJsValue(implicit
+    maxDepth: Depth = defaultMaxDepth,
+    maxWidth: Width = defaultMaxWidth): Arbitrary[JsValue] = Arbitrary(genJsValue)
+
+  implicit def arbJsObject(implicit
+    maxDepth: Depth = defaultMaxDepth,
+    maxWidth: Width = defaultMaxWidth): Arbitrary[JsObject] = Arbitrary(genJsObject)
+
+  implicit def arbJsArray(implicit
+    maxDepth: Depth = defaultMaxDepth,
+    maxWidth: Width = defaultMaxWidth): Arbitrary[JsArray] = Arbitrary(genJsArray)
+
+  implicit def arbJsString(implicit arbString: Arbitrary[String]): Arbitrary[JsString] = Arbitrary {
+    arbString.arbitrary map JsString
+  }
+
+  implicit def arbJsNumber: Arbitrary[JsNumber] = Arbitrary {
+    genSafeBigDecimal map JsNumber
+  }
+
+  implicit def arbJsBoolean: Arbitrary[JsBoolean] = Arbitrary {
+    Gen.oneOf(true, false) map JsBoolean
+  }
+
+  val genSafeBigDecimal: Gen[BigDecimal] = genSafeBigDecimal(JsonParserSettings.settings)
+
+  /**
+   * The Jaxson parser has trouble with very large exponents of BigDecimals.
+   *
+   * I couldn't quite pin the problem down to precision, scale, or both, so
+   */
+  def genSafeBigDecimal(parseSettings: JsonParserSettings): Gen[BigDecimal] = {
+    def chooseBigInt: Gen[BigInt] =
+      sized((s: Int) => choose(-s, s)) map (x => BigInt(x))
+    def genBigInt: Gen[BigInt] = Gen.frequency(
+      (10, chooseBigInt),
+      (1, BigInt(0)),
+      (1, BigInt(1)),
+      (1, BigInt(-1)),
+      (1, BigInt(Int.MaxValue) + 1),
+      (1, BigInt(Int.MinValue) - 1),
+      (1, BigInt(Long.MaxValue)),
+      (1, BigInt(Long.MinValue)),
+      (1, BigInt(Long.MaxValue) + 1),
+      (1, BigInt(Long.MinValue) - 1)
+    )
+    for {
+      x <- genBigInt
+      // Generates numbers outside the range of a Double without breaking the Jaxson parser.
+      scale <- Gen.chooseNum(0, parseSettings.bigDecimalParseSettings.scaleLimit)
+    } yield BigDecimal(x, scale, parseSettings.bigDecimalParseSettings.mathContext)
+  }
+
+  /**
+   * Generates non-nested [[JsValue]]s (ie. not [[JsArray]] or [[JsObject]]).
+   */
+  def genJsPrimitive: Gen[JsValue] = {
+    Gen.oneOf(
+      arbJsBoolean.arbitrary,
+      arbJsNumber.arbitrary,
+      arbJsString.arbitrary,
+      Gen.const(JsNull)
+    )
+  }
+
+  /**
+   * Generates a primitive or nested [[JsValue]] up to the specified depth and width
+   *
+   * @param maxDepth see [[defaultMaxDepth]] (cannot be less than 0)
+   * @param maxWidth see [[defaultMaxWidth]] (cannot be less than 0)
+   */
+  def genJsValue(implicit maxDepth: Depth = defaultMaxDepth, maxWidth: Width = defaultMaxWidth): Gen[JsValue] = {
+    if (maxDepth === 0) genJsPrimitive
+    else Gen.oneOf(
+      genJsPrimitive,
+      // The Scala compiler has a bug with AnyVal, where it favors implicits in the outer scope
+      genJsArray(maxDepth, maxWidth),
+      genJsObject(maxDepth, maxWidth)
+    )
+  }
+
+  /**
+   * Generates a nested array at the specified depth and width.
+   *
+   * @note the arrays may contain mixed type values at different depths, but never deeper than the [[defaultMaxDepth]].
+   *
+   * @param maxDepth see [[defaultMaxDepth]] (cannot be less than 1)
+   * @param maxWidth see [[defaultMaxWidth]] (cannot be less than 1)
+   */
+  def genJsArray(implicit maxDepth: Depth = defaultMaxDepth, maxWidth: Width = defaultMaxWidth): Gen[JsArray] =
+    Gen.listOfN(maxWidth, genJsValue(maxDepth - 1, maxWidth)) map { JsArray(_) }
+
+  /**
+   * Generates a valid field name where the first character is alphabetical and the remaining chars
+   * are alphanumeric.
+   */
+  def genFieldName: Gen[String] = Gen.identifier
+
+  def genFields(implicit maxDepth: Depth = defaultMaxDepth, maxWidth: Width = defaultMaxWidth): Gen[(String, JsValue)] = {
+    // The Scala compiler has a bug with AnyVal, where it favors implicits in the outer scope
+    Gen.zip(genFieldName, genJsValue(maxDepth, maxWidth))
+  }
+
+  /**
+   * Generates a nested array at the specified depth and width.
+   *
+   * @param maxDepth see [[defaultMaxDepth]] (cannot be less than 1)
+   * @param maxWidth see [[defaultMaxWidth]] (cannot be less than 1)
+   */
+  def genJsObject(implicit maxDepth: Depth = defaultMaxDepth, maxWidth: Width = defaultMaxWidth): Gen[JsObject] = {
+    for {
+      fields <- Gen.listOfN(maxWidth, genFields(maxDepth - 1, maxWidth))
+    } yield JsObject(fields)
+  }
+
+  // Shrinks for better error output
+
+  implicit val shrinkJsArray: Shrink[JsArray] = Shrink {
+    arr => shrink(arr.value) map JsArray
+  }
+
+  implicit val shrinkJsObject: Shrink[JsObject] = Shrink {
+    obj => shrink(obj.value) map { fields => JsObject(fields.toSeq) }
+  }
+
+  implicit val shrinkJsValue: Shrink[JsValue] = Shrink {
+    case array: JsArray => shrink(array)
+    case obj: JsObject  => shrink(obj)
+    case JsString(str)  => shrink(str) map JsString
+    case JsNumber(num)  => shrink(num) map JsNumber
+    case other => shrink(other)
+  }
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/SerializationTests.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/SerializationTests.scala
@@ -1,0 +1,156 @@
+package play.api.libs.json.scalacheck
+
+import org.scalacheck.Shrink
+import play.api.libs.json._
+
+import scala.collection.parallel._
+import scala.reflect.ClassTag
+import scala.testing.{GenericTestSuite, TestSuiteBridge}
+import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.{Success, Try}
+
+/**
+ * Mixin that adds some free serialization tests.
+ *
+ * This will add a test that verifies that every model written will be read back to a value that
+ * is equivalent to the original example, and print a detailed error message if not.
+ *
+ * If you have a custom way of determining equality that lives outside of the model class itself,
+ * you can override the methods used for comparison.
+ */
+trait SerializationTests[T] extends GenericTestSuite {
+  self: TestSuiteBridge =>
+
+  type Serialized
+
+  def examples: Seq[T]
+
+  protected def shrink: Shrink[T]
+
+  protected def clsTag: ClassTag[T]
+
+  protected def className: String = clsTag.runtimeClass.getSimpleName
+
+  protected def serialize(model: T): Serialized
+
+  /**
+   * A function that either returns an error message or the deserialized model.
+   */
+  protected def deserialize(serialized: Serialized): Either[String, T]
+
+  /**
+   * Override this method to define a way to serialize the test json to a human-friendly format.
+   */
+  protected def prettyPrint(serialized: Serialized): String
+
+  /**
+   * Override this method if you want to define a different way to assert equality than the test
+   * framework supplies by default.
+   */
+  protected def assertPostSerializationEquality(expected: T, actual: T): Unit = self.assertEqual(expected, actual)
+
+  /**
+   * Override this method if you want to print a different error on failure.
+   */
+  protected def assertSame(expected: T, actual: T, serialized: Serialized): Unit = {
+    try assertPostSerializationEquality(expected, actual)
+    catch {
+      case NonFatal(exception) =>
+        val prettyOutput = prettyPrint(serialized)
+        fail(
+          s"The expected and actual values are not equal.\n\n" +
+          s"expected:\n$expected\n\n" +
+          s"actual:\n$actual\n\n" +
+          s"json:\n$prettyOutput\n\n",
+          exception
+        )
+    }
+  }
+
+  /**
+   * Uses the provided [[shrink]] to shrink a failing example to its simplest form that still fails the test.
+   *
+   * @note you can override this method to just call [[assertSame]] if you don't want to apply the shrink.
+   */
+  protected def assertSameWithShrink(expected: T, actual: T, serialized: Serialized): Unit = {
+    try assertSame(expected, actual, serialized)
+    catch {
+      case NonFatal(originalEx) =>
+        var lastEx = originalEx
+        var shrinks = 0
+        for (simpler <- shrink.shrink(expected)) {
+          shrinks += 1
+          val output = Try(serialize(simpler)) getOrElse { throw lastEx }
+          val expected = Try(deserialize(output)) match {
+            case Success(Right(o)) => o
+            case _ => throw lastEx
+          }
+          try assertSame(simpler, expected, output)
+          catch {
+            case NonFatal(ex) => lastEx = ex
+          }
+        }
+        lastEx.addSuppressed(new RuntimeException(s"Applied $shrinks shrinks") with NoStackTrace)
+        throw lastEx
+    }
+  }
+
+  // Register the actual test
+  addTest(s"Format[$className] should read the JsValue that it writes") {
+    val decomposed = ParSeq(examples: _*) map serialize
+    val reconstructed = decomposed map { written =>
+      val pretty = prettyPrint(written)
+      val result = deserialize(written)
+      result match {
+        case Right(model) =>
+          model
+        case Left(errorMsg) =>
+          fail(s"Could not read an instance of $className from:\n$pretty\n\nPlay detected errors:\n$errorMsg\n")
+      }
+    }
+    for (((expected, actual), asWritten) <- examples zip reconstructed zip decomposed) {
+      assertSameWithShrink(expected, actual, asWritten)
+    }
+  }
+}
+
+/**
+ * A mixin for adding Play serialization tests.
+ */
+trait PlaySerializationTests[T] extends SerializationTests[T] {
+  self: TestSuiteBridge =>
+
+  override type Serialized = JsValue
+
+  protected implicit def playFormat: Format[T]
+
+  override protected def serialize(model: T): Serialized = Json.toJson(model)
+
+  override protected def deserialize(serialized: Serialized): Either[String, T] = serialized.validate[T] match {
+    case JsSuccess(model, _) => Right(model)
+    case JsError(errors)     => Left(prettyPrint(JsError.toJson(errors)))
+  }
+
+  override protected def prettyPrint(serialized: Serialized): String = Json.prettyPrint(serialized)
+}
+
+/**
+ * Extend this to perform Play serialization tests.
+ *
+ * This provides a sample constructor that is easy to fulfill in the subclass.
+ */
+abstract class PlayJsonFormatTests[T](
+  override val examples: Seq[T],
+  override protected implicit val playFormat: Format[T],
+  override protected val clsTag: ClassTag[T],
+  override protected val shrink: Shrink[T]
+) extends PlaySerializationTests[T] {
+   self: TestSuiteBridge =>
+
+  /* sadly alternate constructors do not work with self-types properly in Scala 2.10,
+   * and an implicit argument list would have the same signature after type erasure
+   * so it is up to the subclasses to provide a more user-friendly constructor that
+   * combines the class with the self-type requirement.
+   **/
+
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Width.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalacheck/Width.scala
@@ -1,0 +1,23 @@
+package play.api.libs.json.scalacheck
+
+import scala.language.implicitConversions
+
+class Width private[Width] (val width: Int) extends AnyVal with Counted {
+  override protected def throwOnNegative(): Nothing = throw new IllegalArgumentException("Width cannot be negative")
+  @inline override def count: Int = width
+  def -(that: Width) = Width(this.width - that.width)
+  def +(that: Width) = new Width(this.width + that.width)  // no need to validate
+}
+
+object Width extends (Int => Width) {
+
+  implicit def fromInt(int: Int): Width = Width(int)
+
+  implicit def toInt(width: Width): Int = width.width
+
+  override def apply(width: Int): Width = {
+    val w = new Width(width)
+    w.validate()
+    w
+  }
+}

--- a/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalatest/PlayJsonFormatSpec.scala
+++ b/play28-json-tests-sc14/src/main/scala/play/api/libs/json/scalatest/PlayJsonFormatSpec.scala
@@ -2,6 +2,7 @@ package play.api.libs.json.scalatest
 
 import org.scalacheck.ops._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.Tag
 import org.scalatest.flatspec.AnyFlatSpecLike
 import play.api.libs.json.Format
 import play.api.libs.json.scalacheck.PlayJsonFormatTests
@@ -23,8 +24,12 @@ class PlayJsonFormatSpec[T](examples: Seq[T])(implicit playFormat: Format[T], cl
   with AnyFlatSpecLike
   with ScalaTestBridge {
 
+  override def registerTest(testText: String, testTags: Tag*)(testFun: => Unit): Unit = {
+    super[AnyFlatSpecLike].registerTest(testText, testTags: _*)(testFun)
+  }
+
   def this(gen: Gen[T], samples: Int)(implicit playFormat: Format[T], clsTag: ClassTag[T], shrink: Shrink[T]) =
-    this(gen.iterator.take(samples).toSeq)
+    this(gen.toIterator.take(samples).toSeq)
 
   def this(gen: Gen[T])(implicit playFormat: Format[T], clsTag: ClassTag[T], shrink: Shrink[T]) = this(gen, 100)
 

--- a/play28-json-tests-sc14/src/main/scala/scala/concurrent/duration/ops/v4/FiniteDurationOps.scala
+++ b/play28-json-tests-sc14/src/main/scala/scala/concurrent/duration/ops/v4/FiniteDurationOps.scala
@@ -1,0 +1,61 @@
+package scala.concurrent.duration.ops.v4
+
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+
+/**
+ * Provides useful operations on [[FiniteDuration]]s.
+ */
+object FiniteDurationOps {
+
+  /**
+   * Same as [[Duration.toUnit]] except avoids loss of precision by not converting to Double first.
+   *
+   * @param duration the duration to convert
+   * @param unit the [[TimeUnit]] to convert it to
+   */
+  def convertToUnitPrecisely(duration: FiniteDuration, unit: TimeUnit): FiniteDuration = {
+    val magnitude = unit match {
+      case DAYS         => duration.toDays
+      case HOURS        => duration.toHours
+      case MICROSECONDS => duration.toMicros
+      case MILLISECONDS => duration.toMillis
+      case MINUTES      => duration.toMinutes
+      case NANOSECONDS  => duration.toNanos
+      case SECONDS      => duration.toSeconds
+    }
+    Duration(magnitude, unit)
+  }
+}
+
+/**
+ * Provides additional operations on [[FiniteDuration]] with no runtime allocation overhead.
+ */
+class FiniteDurationOps(val duration: FiniteDuration) extends AnyVal {
+
+  /**
+   * Drops any extra precision that would be unrepresentable in the current Duration's [[TimeUnit]].
+   */
+  def dropInsignificantDigits: FiniteDuration = toUnitPrecise(duration.unit)
+
+  /**
+   * Converts a [[FiniteDuration]] to the provided unit without any loss of precision.
+   *
+   * @note this method has no affect on [[Duration.Infinite]] values
+   *
+   * @param unit the [[TimeUnit]], such as [[DAYS]], [[HOURS]], etc
+   * @return a new [[FiniteDuration]] with the provided unit or the given [[Duration.Infinite]]
+   */
+  def toUnitPrecise(unit: TimeUnit): FiniteDuration = FiniteDurationOps.convertToUnitPrecisely(duration, unit)
+}
+
+/**
+ * Extend this trait to get additional operations on [[FiniteDuration]]s.
+ *
+ * These are also made available by adding `import scala.concurrent.duration.ops._`
+ */
+trait DurationImplicits {
+
+  implicit def fromFiniteDuration(duration: FiniteDuration): FiniteDurationOps =
+    new FiniteDurationOps(duration)
+}

--- a/play28-json-tests-sc14/src/main/scala/scala/concurrent/duration/ops/v4/package.scala
+++ b/play28-json-tests-sc14/src/main/scala/scala/concurrent/duration/ops/v4/package.scala
@@ -1,0 +1,3 @@
+package scala.concurrent.duration.ops
+
+package object v4 extends DurationImplicits

--- a/play28-json-tests-sc14/src/main/scala/scala/testing/GenericTestSuite.scala
+++ b/play28-json-tests-sc14/src/main/scala/scala/testing/GenericTestSuite.scala
@@ -1,0 +1,23 @@
+package scala.testing
+
+/**
+ * A trait that provides early initialization of the tests in a way that is agnostic to any test runner.
+ *
+ * Any generic tests should extend from this trait to ensure that any registered tests are delayed until
+ * the appropriate [[TestSuiteBridge]] (and associated Suite class) has been constructed.
+ *
+ * The self-type [[TestSuiteBridge]] should be carried along as a self-type to provide a better error
+ * message for the implementing test suite.
+ *
+ * It will construct a holder for the tests before executing the body of the test suite runs to avoid
+ * any NullPointerExceptions when attempting to register a test.
+ */
+trait GenericTestSuite {
+  self: TestSuiteBridge =>
+
+  protected[testing] var tests: Map[String, () => Unit] = Map.empty
+
+  protected def addTest(name: String)(f: => Unit): Unit = {
+    tests += (name, () => f)
+  }
+}

--- a/play28-json-tests-sc14/src/main/scala/scala/testing/TestSuiteBridge.scala
+++ b/play28-json-tests-sc14/src/main/scala/scala/testing/TestSuiteBridge.scala
@@ -1,0 +1,49 @@
+package scala.testing
+
+/**
+ * Defines a generic set of operations required to setup tests to run in the desired test framework.
+ *
+ * This allows libraries to provide generic test suites that can be extended for free automated tests.
+ * Yes, FREE! This allows you to inherit automated tests, and get them... automatically.
+ *
+ * There is currently only one subclass for this [[scala.testing.scalatest.ScalaTestBridge]]
+ */
+trait TestSuiteBridge extends GenericTestSuite {
+
+  /**
+   * Use the underlying test framework's assertion method to compare the left element to the right.
+   */
+  protected def assertEqual[T](left: T, right: T): Unit
+
+  /**
+   * A convenient test failure method that throws an exception.
+   *
+   * @note This should always call the [[doFail]]
+   */
+  protected def fail(): Nothing = doFail(None, None)
+
+  protected def fail(reason: String): Nothing = doFail(Some(reason), None)
+
+  protected def fail(cause: Throwable): Nothing = doFail(None, Some(cause))
+
+  protected def fail(reason: String, cause: Throwable): Nothing = doFail(Some(reason), Some(cause))
+
+  /**
+   * All convenience fail methods should come through this fail method.
+   *
+   * @note The above fail methods are not marked final because they may collide with the methods
+   *       provided by the test library, however, they should only be overriden to call this method.
+   *
+   * @param optReason the reason for the test failure
+   * @param optCause the exception that caused the test failure, if available
+   * @return
+   */
+  protected def doFail(optReason: Option[String], optCause: Option[Throwable]): Nothing
+
+  protected[testing] def registerTests(tests: Map[String, () => Unit]): Unit
+
+  /**
+   * Called after the Suite has extended the required implementation for registering tests.
+   */
+  protected[testing] def registerTests(): Unit = registerTests(tests)
+}

--- a/play28-json-tests-sc14/src/main/scala/scala/testing/scalatest/ScalaTestBridge.scala
+++ b/play28-json-tests-sc14/src/main/scala/scala/testing/scalatest/ScalaTestBridge.scala
@@ -1,0 +1,41 @@
+package scala.testing.scalatest
+
+import org.scalatest.{Suite, Tag}
+
+import scala.testing.TestSuiteBridge
+
+/**
+ * Provides the operations required for [[TestSuiteBridge]], using the methods from ScalaTest's [[Suite]].
+ *
+ * Extend this class along with your preferred flavor of [[Suite]] to fulfill the required operations
+ * for [[TestSuiteBridge]].
+ */
+trait ScalaTestBridge extends TestSuiteBridge with Suite {
+
+  override protected def assertEqual[T](left: T, right: T): Unit = assert(left == right)
+
+  override def fail(): Nothing                                  = super[TestSuiteBridge].fail()
+  override def fail(message: String): Nothing                   = super[TestSuiteBridge].fail(message)
+  override def fail(message: String, cause: Throwable): Nothing = super[TestSuiteBridge].fail(message, cause)
+  override def fail(cause: Throwable): Nothing                  = super[TestSuiteBridge].fail(cause)
+
+  override protected def doFail(optReason: Option[String], optCause: Option[Throwable]): Nothing = {
+    (optReason, optCause) match {
+      case (Some(reason), Some(cause)) => super[Suite].fail(reason, cause)
+      case (Some(reason), None)        => super[Suite].fail(reason)
+      case (None, Some(cause))         => super[Suite].fail(cause)
+      case (None, None)                => super[Suite].fail()
+    }
+  }
+
+  def registerTest(testText: String, testTags: Tag*)(testFun: => Unit): Unit
+
+  override protected[testing] def registerTests(tests: Map[String, () => Unit]): Unit = {
+    for ((name, test) <- tests) {
+      registerTest(name)(test())
+    }
+  }
+
+  // register the tests after the Suite has been initialized
+  registerTests()
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/AbstractJsonOpsSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/AbstractJsonOpsSpec.scala
@@ -1,0 +1,239 @@
+package play.api.libs.json.ops.v4
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json._
+
+class AbstractJsonOpsSpec extends AnyWordSpec
+  with ScalaCheckDrivenPropertyChecks
+  with ExampleGenerators
+  with Matchers {
+
+  "AbstractJsonOps.formatWithTypeKeyOf" should {
+
+    "write the the type key, along with the value, if present" in {
+      forAll { (o: SingleField) =>
+        val json = Json.toJson(o)
+        val expectedKey = Json.obj(Generic.keyFieldName -> o.key)
+        // exclude the invisible values
+        val expectedValue = if (o.hidesValueFromJson) Json.obj() else Json.obj("value" -> o.value)
+        val expected = expectedKey ++ expectedValue
+        assertResult(expected)(json)
+      }
+    }
+  }
+
+  "AbstractJsonOps.formatAbstract" should {
+
+    "read what it writes" in {
+      forAll { (o: Generic) =>
+        val json = Json.toJson(o)
+        val parsed = json.as[Generic]
+        assertResult(o, "the deserialized value did not equal the original pre-serialized value")(parsed)
+      }
+    }
+
+    "fail with an UnrecognizedTypeKeyException exception when the key is unmatched" in {
+      val brokenFormat: OFormat[Generic] = Json.formatAbstract[Generic] {
+        case SpecificFieldA.key => OFormat.of[SpecificFieldA]
+        // oops, forgot to add format for B
+      }
+      val a: Generic = genA.sample.get
+      Json.toJson(a)(brokenFormat)  // should be fine
+      val b: Generic = genB.sample.get
+      an[UnrecognizedTypeKeyException] shouldBe thrownBy { Json.toJson(b)(brokenFormat) }
+    }
+
+    "fail with an WrongAbstractFormatException exception when the wrong OFormat used" in {
+      val brokenFormat: OFormat[Generic] = Json.formatAbstract[Generic] {
+        case SpecificFieldA.key => OFormat.of[SpecificFieldA]
+        case SpecificFieldB.key => OFormat.of[SpecificFieldA]  // oops, this should be B
+      }
+      val a: Generic = genA.sample.get
+      Json.toJson(a)(Generic.format)  // should be fine
+      val b: Generic = genB.sample.get
+      an[WrongAbstractFormatException] shouldBe thrownBy { Json.toJson(b)(brokenFormat) }
+    }
+  }
+
+  "AbstractJsonOps.usingKeyObject" should {
+
+    "allow custom logic to occur in the pattern matching type key" in {
+      val keyPath = __ \ "even"
+      val evenJson = keyPath.write[Boolean].writes(true)
+      val oddJson = keyPath.write[Boolean].writes(false)
+      val evenValue = 2
+      val oddValue = 3
+      val extractor = TypeKeyExtractor.extractTypeKey[Int].usingKeyObject(keyPath -> Reads.of[Boolean]) {
+        case even if even % 2 == 0 => evenJson
+        case odd => oddJson
+      }
+      val fancyFormat: OFormat[Int] = Json.formatAbstract[Int] {
+        case true => OFormat.pure(evenValue, evenJson)
+        case false => OFormat.pure(oddValue, oddJson)
+      } (extractor)
+      for (n <- 0 to 10) {
+        def isEven = n % 2 == 0
+        val nJson = Json.toJson(n)(fancyFormat)
+        assertResult(if (isEven) evenJson else oddJson) {
+          nJson
+        }
+        val backToInt = Json.fromJson[Int](nJson)(fancyFormat)
+        assertResult(if (isEven) JsSuccess(evenValue, keyPath) else JsSuccess(oddValue, keyPath)) {
+          backToInt
+        }
+      }
+    }
+
+    "fail with an JsonTypeKeyReadException when the extractor cannot distinguish which is the unique key" in {
+      val duplicateValue = "duplicate"
+      val duplicateJson = Json.obj(
+        "key1" -> duplicateValue,
+        "key2" -> duplicateValue
+      )
+      val extractor = TypeKeyExtractor.extractTypeKey[String].usingKeyObject(
+        __ \ "key1" -> Reads.of[String],
+        __ \ "key2" -> Reads.of[String]
+      ) {
+        case `duplicateValue` => duplicateJson
+      }
+      a [JsonTypeKeyReadException] shouldBe thrownBy {
+        extractor.readKeyFromModel(duplicateValue)
+      }
+    }
+  }
+}
+
+trait ExampleGenerators {
+
+  def genA: Gen[SpecificFieldA] = Gen.identifier.map(SpecificFieldA(_))
+
+  def genB: Gen[SpecificFieldB] = Gen.identifier.map(SpecificFieldB(_))
+
+  def genC: Gen[SpecificObjectC.type] = Gen.const(SpecificObjectC)
+
+  def genD: Gen[SpecificObjectD.type] = Gen.const(SpecificObjectD)
+
+  def genE: Gen[ComplexStringKey] = {
+    for {
+      id <- Gen.identifier
+      value <- Gen.alphaStr
+      otherString <- Gen.alphaStr
+    } yield ComplexStringKey(id, value, otherString)
+  }
+
+  def genF: Gen[ComplexBooleanKey] = {
+    for {
+      id <- Gen.identifier
+      value <- Gen.alphaStr
+      otherBoolean <- Gen.oneOf(true, false)
+    } yield ComplexBooleanKey(id, value, otherBoolean)
+  }
+
+  def genSpecific: Gen[SingleField] = Gen.oneOf(genA, genB, genC, genD)
+
+  def genComplex: Gen[ComplexKey] = Gen.oneOf(genE, genF)
+
+  implicit val arbSpecific: Arbitrary[SingleField] = Arbitrary(genSpecific)
+
+  implicit val arbGeneric: Arbitrary[Generic] = Arbitrary {
+    Gen.oneOf(genSpecific, genComplex)
+  }
+}
+
+sealed trait Generic {
+  def key: String
+  def value: String
+}
+
+object Generic {
+
+  val keyFieldName = "key"
+
+  implicit val extractor: TypeKeyExtractor[Generic] =
+    Json.extractTypeKey[Generic].usingKeyField(_.key, __ \ keyFieldName)
+
+  implicit val format: OFormat[Generic] = Json.formatAbstract[Generic] {
+    case SpecificFieldA.key => OFormat.of[SpecificFieldA]
+    case SpecificFieldB.key => OFormat.of[SpecificFieldB]
+    case SpecificObjectC.key => OFormat.of[SpecificObjectC.type]
+    case SpecificObjectD.key => OFormat.of[SpecificObjectD.type]
+    case ComplexKey.key => OFormat.of[ComplexKey]
+  }
+}
+
+sealed trait SingleField extends Generic {
+  def hidesValueFromJson: Boolean
+}
+object SingleField {
+  implicit val writes: OWrites[SingleField] = OWrites(Generic.format.writes)
+}
+
+case class SpecificFieldA(value: String) extends SingleField {
+  override def key: String = SpecificFieldA.key
+  override def hidesValueFromJson: Boolean = false
+}
+object SpecificFieldA {
+  final val key = "A"
+  implicit val format: OFormat[SpecificFieldA] = Json.formatWithTypeKeyOf[Generic].addedTo(Json.format[SpecificFieldA])
+}
+
+case class SpecificFieldB(value: String) extends SingleField {
+  override def key: String = SpecificFieldB.key
+  override def hidesValueFromJson: Boolean = false
+}
+object SpecificFieldB {
+  final val key = "B"
+  implicit val format: OFormat[SpecificFieldB] = Json.formatWithTypeKeyOf[Generic].addedTo(Json.format[SpecificFieldB])
+}
+
+case object SpecificObjectC extends SingleField {
+  override final val key: String = "C"
+  override def value: String = "invisible constant C"
+  override def hidesValueFromJson: Boolean = true
+  implicit val format: OFormat[this.type] = Json.formatWithTypeKeyOf[Generic].pure(SpecificObjectC)
+}
+
+case object SpecificObjectD extends SingleField {
+  override final val key: String = "D"
+  def value: String = "visible constant D"
+  override def hidesValueFromJson: Boolean = false
+  implicit val format: OFormat[SpecificObjectD.type] =
+    Json.formatWithTypeKeyOf[Generic].pure(SpecificObjectD, Json.obj("value" -> value))
+}
+
+sealed trait ComplexKey extends Generic {
+  def id: String
+  final override def key: String = ComplexKey.key
+}
+object ComplexKey {
+
+  final val key = "Complex"
+
+  implicit val extractor: TypeKeyExtractor[ComplexKey] = AbstractJsonOps.extractTypeKey[ComplexKey].usingKeyObject(
+    (__ \ "otherBoolean") -> Format.of[Boolean],
+    (__ \ "otherString")  -> Format.of[String]
+  ) {
+    case f: ComplexBooleanKey => Json.obj("otherBoolean" -> f.otherBoolean)
+    case e: ComplexStringKey  => Json.obj("otherString" -> e.otherString)
+  }
+
+  implicit val format: OFormat[ComplexKey] = Json.formatAbstract[ComplexKey] {
+    case _: String  => OFormat.of[ComplexStringKey]
+    case _: Boolean => OFormat.of[ComplexBooleanKey]
+  }
+}
+
+case class ComplexStringKey(id: String, value: String, otherString: String) extends ComplexKey
+object ComplexStringKey {
+  implicit val format: OFormat[ComplexStringKey] = Json.formatWithTypeKeyOf[ComplexKey]
+    .addedTo(Json.format[ComplexStringKey])
+}
+
+case class ComplexBooleanKey(id: String, value: String, otherBoolean: Boolean) extends ComplexKey
+object ComplexBooleanKey {
+  implicit val format: OFormat[ComplexBooleanKey] = Json.formatWithTypeKeyOf[ComplexKey]
+    .addedTo(Json.format[ComplexBooleanKey])
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/CompatibilityImplicits.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/CompatibilityImplicits.scala
@@ -1,0 +1,16 @@
+package play.api.libs.json.ops.v4
+
+import play.api.libs.json.JsValue
+
+import scala.language.implicitConversions
+
+private[ops] object CompatibilityImplicits extends CompatibilityImplicits
+private[ops] trait CompatibilityImplicits {
+
+  implicit def asJsLookupLike(legacyLookup: JsValue): JsLookupCompat = new JsLookupCompat(legacyLookup)
+}
+
+class JsLookupCompat(protected val legacyLookup: JsValue) extends AnyVal {
+
+  def get: JsValue = legacyLookup
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/DurationFormatSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/DurationFormatSpec.scala
@@ -1,0 +1,41 @@
+package play.api.libs.json.ops.v4
+
+import org.scalacheck.Arbitrary.arbitrary
+import play.api.libs.json.scalacheck.DurationGenerators._
+import play.api.libs.json.scalatest.PlayJsonFormatSpec
+
+import scala.concurrent.duration._
+
+class FiniteDurationArrayFormatSpec extends PlayJsonFormatSpec[FiniteDuration](
+  arbitrary[FiniteDuration])(DurationFormat.array.finiteDurationFormat, implicitly, implicitly)
+  with AssertDurationEquality[FiniteDuration]
+
+class FiniteDurationStringFormatSpec extends PlayJsonFormatSpec[FiniteDuration](
+  arbitrary[FiniteDuration])(DurationFormat.string.finiteDurationFormat, implicitly, implicitly)
+  with AssertDurationEquality[FiniteDuration]
+
+class DurationArrayFormatSpec extends PlayJsonFormatSpec[Duration](
+  arbitrary[Duration])(DurationFormat.array.durationFormat, implicitly, implicitly)
+  with AssertDurationEquality[Duration]
+
+class DurationStringFormatSpec extends PlayJsonFormatSpec[Duration](
+  arbitrary[FiniteDuration])(DurationFormat.string.durationFormat, implicitly, implicitly)
+  with AssertDurationEquality[Duration]
+
+private[ops] trait AssertDurationEquality[T <: Duration] extends PlayJsonFormatSpec[T] {
+
+  override protected def assertPostSerializationEquality(expected: T, actual: T): Unit = {
+    if (expected.isFinite) {
+      assert(actual.isFinite, s"$actual is not finite and cannot be equal to $expected")
+      assertResult(expected.unit)(actual.unit)
+      assertResult(expected.length)(actual.length)
+    }
+    else if (expected eq Duration.Undefined) {
+      assertResult(Duration.Undefined)(actual)
+    }
+    else {
+      assert(!actual.isFinite, s"$actual is finite and cannot be equal to $expected")
+      assertResult(expected)(actual)
+    }
+  }
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/FormatOpsSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/FormatOpsSpec.scala
@@ -1,0 +1,106 @@
+package play.api.libs.json.ops.v4
+
+import org.scalatest.freespec.AnyFreeSpec
+import play.api.libs.json._
+
+class FormatOpsSpec extends AnyFreeSpec {
+
+  "Format.empty" - {
+    val formatEmpty = Format.empty(Nil)
+
+    "reads Nil" in {
+      assertResult(JsSuccess(Nil)) {
+        formatEmpty.reads(Json.arr())
+      }
+    }
+
+    "writes Nil" in {
+      assertResult(Json.arr()) {
+        formatEmpty.writes(Nil)
+      }
+    }
+
+    "invalidate a non-empty array" in {
+      val result = formatEmpty.reads(Json.arr(1))
+      assert(result.isError)
+    }
+
+    "not compile when writing an empty seq" in {
+      assertDoesNotCompile {
+        """formatEmptyList.writes(Seq())"""
+      }
+    }
+  }
+
+  "Format.enumValueString" - {
+    val formatEnumString = Format.enumValueString(EnumExample)
+
+    "reads a valid value" in {
+      assertResult(JsSuccess(EnumExample.A)) {
+        formatEnumString.reads(JsString(EnumExample.A.toString))
+      }
+    }
+
+    "fails to read an invalid value" in {
+      assertResult(JsError("error.expected.enumexample: No value found for 'ERROR'")) {
+        formatEnumString.reads(JsString("ERROR"))
+      }
+    }
+
+    "writes am enum value" in {
+      assertResult(JsString(EnumExample.A.toString)) {
+        formatEnumString.writes(EnumExample.A)
+      }
+    }
+
+    "not write a string" in {
+      assertDoesNotCompile {
+        """formatEnumString.writes("A")"""
+      }
+    }
+  }
+
+  "Format.pure" - {
+
+    "read the expected object" in {
+      assertResult(PureObjectExample) {
+        PureObjectExample.format.reads(JsBoolean(false)).get // any value will read PureExample
+      }
+    }
+
+    "write the expected json" in {
+      assertResult(PureObjectExample.alwaysWritenAs) {
+        PureObjectExample.format.writes(PureObjectExample)
+      }
+    }
+  }
+
+  "OFormat.pure" - {
+
+    "read the expected object" in {
+      assertResult(PureObjectExample) {
+        PureObjectExample.oformat.reads(JsBoolean(false)).get // any value will read PureExample
+      }
+    }
+
+    "write the expected json" in {
+      assertResult(PureObjectExample.alwaysWritenAsObject) {
+        PureObjectExample.oformat.writes(PureObjectExample)
+      }
+    }
+  }
+
+}
+
+object PureObjectExample {
+
+  val alwaysWritenAs: JsValue = JsString("pure")
+  val alwaysWritenAsObject: JsObject = Json.obj("value" -> alwaysWritenAs)
+
+  val format: Format[PureObjectExample.type] = Format.pure(this, alwaysWritenAs)
+  val oformat: OFormat[PureObjectExample.type] = OFormat.pure(this, alwaysWritenAsObject)
+}
+
+object EnumExample extends Enumeration {
+  val A, B, C = Value
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/JsValueOpsSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/JsValueOpsSpec.scala
@@ -1,0 +1,53 @@
+package play.api.libs.json.ops.v4
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
+import play.api.libs.json._
+import play.api.libs.json.scalacheck.JsValueGenerators
+
+case class Troll(value: String)
+
+object Troll {
+  implicit val format: OFormat[Troll] = Json.format[Troll]
+}
+
+class JsValueOpsSpec extends AnyFlatSpec
+  with CompatibilityImplicits
+  with JsValueGenerators {
+
+  implicit val arbTroll: Arbitrary[Troll] = Arbitrary(Gen.identifier.map(Troll(_)))
+
+  "transformAs" should "use the implicit JsonTransform" in {
+    val troll = JsString("trolled :)")
+    implicit val transform: JsonTransform[Troll] = JsonTransform(_ => troll)
+    forAll() { json: JsValue =>
+      assertResult(troll) {
+        json.transformAs[Troll]
+      }
+    }
+  }
+
+  behavior of "asOrThrow"
+
+  it should "convert the json as normal" in {
+    implicit val transform: JsonTransform[Troll] = JsonTransform.redactPaths[Troll](Seq(__ \ "value"))
+    forAll() { troll: Troll =>
+      assertResult(troll) {
+        Json.toJson(troll).asOrThrow[Troll]
+      }
+    }
+  }
+
+  it should "transform the json when throwing an exception" in {
+    implicit val transform: JsonTransform[Troll] = JsonTransform.redactPaths[Troll](Seq(__ \ "value"))
+    forAll() { json: JsObject =>
+      val ex = intercept[InvalidJsonException] {
+        json.asOrThrow[Troll]
+      }
+      assertResult(JsonTransform.RedactedValue) {
+        (ex.json \ "value").get
+      }
+    }
+  }
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/JsonTransformSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/JsonTransformSpec.scala
@@ -1,0 +1,63 @@
+package play.api.libs.json.ops.v4
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
+import play.api.libs.json._
+import play.api.libs.json.scalacheck.JsValueGenerators
+
+import scala.annotation.tailrec
+import scala.util.Random
+
+class JsonTransformSpec extends AnyFlatSpec
+with CompatibilityImplicits
+with JsValueGenerators {
+
+  @tailrec private def verifyAllRedacted(all: Seq[(JsPath, JsValue)]): Unit = {
+    val invalid = all collect {
+      case (path, value) if value != JsonTransform.RedactedValue => path
+    }
+    assert(invalid.isEmpty, s"The following paths are invalid: ${invalid.mkString(", ")}")
+    val nextGen = all flatMap {
+      case (path, JsArray(items)) => items.zipWithIndex map {
+        case (item, i) => (JsPath(path.path :+ IdxPathNode(i)), item)
+      }
+      case (path, JsObject(fields)) => fields map {
+        case (k, v) => (path \ k, v)
+      }
+      case _ => Nil
+    }
+    if (nextGen.nonEmpty) {
+      verifyAllRedacted(nextGen)
+    }
+  }
+
+  "redactPaths" should "redact selected fields by path at the top level" in {
+    forAll { obj: JsObject =>
+      val topLevelPaths: Seq[JsPath] = obj.fields.map(__ \ _._1).toSeq
+      whenever(topLevelPaths.nonEmpty) {
+        val redactedPaths: Seq[JsPath] = Random.shuffle(topLevelPaths) take Random.nextInt(topLevelPaths.size)
+        implicit val redactor: JsonTransform[Any] = JsonTransform.redactPaths[Any](redactedPaths)
+        val redacted = obj.transformAs[Any]
+        // Useful for debugging
+//        if (redactedPaths.nonEmpty) {
+//          println(Json.prettyPrint(obj))
+//          println(s"with redacted paths (${redactedPaths.mkString(", ")}):")
+//          println(Json.prettyPrint(redacted))
+//        }
+        for (path <- redactedPaths) {
+          assertResult(JsonTransform.RedactedValue) {
+            path.asSingleJson(redacted).get
+          }
+        }
+      }
+    }
+  }
+
+  "redactAll" should "redact all fields of all paths" in {
+    implicit val redactor: JsonTransform[Any] = JsonTransform.redactAll[Any]()
+    forAll { obj: JsObject =>
+      val redacted = obj.transformAs[Any]
+      verifyAllRedacted(Seq(__ -> redacted))
+    }
+  }
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/PlayJsonMacrosSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/PlayJsonMacrosSpec.scala
@@ -1,0 +1,145 @@
+package play.api.libs.json.ops.v4
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{Json, Reads}
+
+import scala.collection.mutable
+
+class PlayJsonMacrosSpec extends AnyFunSpec with Matchers {
+
+  case class TestA(strings: List[String])
+  object TestA extends TolerantContainerFormats {
+    implicit val TestAReads: Reads[TestA] = PlayJsonMacros.nullableReads[TestA]
+  }
+
+  case class TestB(strings: Seq[String])
+  object TestB extends TolerantContainerFormats {
+    implicit val TestBReads: Reads[TestB] = PlayJsonMacros.nullableReads[TestB]
+  }
+
+  case class TestC(testA: Set[TestA], testB: mutable.ArraySeq[TestB])
+  object TestC extends TolerantContainerFormats {
+    implicit val TestCReads: Reads[TestC] = PlayJsonMacros.nullableReads[TestC]
+  }
+
+  describe("PlayJsonMacrosSpec") {
+    it("should deserialize a TestA when TestA is populated") {
+      val jsonStr =
+        """
+          |{"strings":["string1", "string2"]}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testA = json.as[TestA]
+
+      assert(testA == TestA(List("string1", "string2")))
+    }
+
+    it("should deserialize a TestA when TestA is empty") {
+      val jsonStr =
+        """
+          |{"strings":[]}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testA = json.as[TestA]
+
+      assert(testA == TestA(List.empty[String]))
+    }
+
+    it("should deserialize a TestA when TestA has field missing") {
+      val jsonStr =
+        """
+          |{}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testA = json.as[TestA]
+
+      assert(testA == TestA(List.empty[String]))
+    }
+
+    it("should deserialize a TestB when TestB is populated") {
+      val jsonStr =
+        """
+          |{"strings":["string1", "string2"]}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testB = json.as[TestB]
+
+      assert(testB == TestB(List("string1", "string2")))
+    }
+
+    it("should deserialize a TestB when TestB is empty") {
+      val jsonStr =
+        """
+          |{"strings":[]}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testB = json.as[TestB]
+
+      assert(testB == TestB(List.empty[String]))
+    }
+
+    it("should deserialize a TestB when TestB has field missing") {
+      val jsonStr =
+        """
+          |{}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testB = json.as[TestB]
+
+      assert(testB == TestB(List.empty[String]))
+    }
+
+    it("should deserialize a TestC when TestC is populated") {
+      val jsonStr =
+        """
+          |{
+          |"testA":[{"strings":["stringZ", "stringX"]}],
+          |"testB":[{"strings":["stringA", "stringB"]}]
+          |}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testC = json.as[TestC]
+
+      assert(testC == TestC(Set(TestA(List("stringZ", "stringX"))), mutable.ArraySeq(TestB(List("stringA", "stringB")))))
+    }
+
+    it("should deserialize a TestC when parts of testC are empty") {
+      val jsonStr =
+        """
+          |{
+          |"testA":[{}],
+          |"testB":[]
+          |}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testC = json.as[TestC]
+
+      assert(testC == TestC(Set(TestA(List.empty[String])), mutable.ArraySeq.empty[TestB]))
+    }
+
+    it("should deserialize a TestC when parts of testC are missing") {
+      val jsonStr =
+        """
+          |{
+          |"testB":[]
+          |}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testC = json.as[TestC]
+
+      assert(testC == TestC(Set.empty[TestA], mutable.ArraySeq.empty[TestB]))
+    }
+
+    it("should deserialize a TestC when all of testC is missing") {
+      val jsonStr =
+        """
+          |{}
+        """.stripMargin
+      val json = Json.parse(jsonStr)
+      val testC = json.as[TestC]
+
+      assert(testC == TestC(Set.empty[TestA], mutable.ArraySeq.empty[TestB]))
+    }
+  }
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/package.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/ops/v4/package.scala
@@ -1,0 +1,3 @@
+package play.api.libs.json.ops
+
+package object v4 extends JsonImplicits

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/DurationGeneratorsSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/DurationGeneratorsSpec.scala
@@ -1,0 +1,27 @@
+package play.api.libs.json.scalacheck
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.scalacheck.DurationGenerators._
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+class DurationGeneratorsSpec extends AnyWordSpec
+  with ScalaCheckDrivenPropertyChecks {
+
+  "Arbitrary[FiniteDuration]" should {
+    "always produce a valid finite value" in {
+      forAll() { (duration: FiniteDuration) =>
+        assert(duration.isFinite)
+      }
+    }
+  }
+
+  "Arbitrary[Duration]" should {
+    "always produce a valid value" in {
+      forAll() { (duration: Duration) =>
+        assert(duration ne null)
+      }
+    }
+  }
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/JsValueGeneratorsSpec.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/JsValueGeneratorsSpec.scala
@@ -1,0 +1,157 @@
+package play.api.libs.json.scalacheck
+
+import org.scalacheck.{Gen, Prop}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Assertions
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json._
+
+import scala.annotation.tailrec
+
+class JsValueGeneratorsSpec extends AnyFlatSpec
+with ScalaCheckDrivenPropertyChecks
+with Matchers
+with JsValueGenerators {
+
+  // Controls the overall time these tests take to run
+  // For better testing coverage, this needs to be greater than defaultMaxDepth / defaultMaxWidth
+  implicit val maxDepth: Depth = defaultMaxDepth + 3
+  implicit val maxWidth: Width = defaultMaxWidth + 3
+
+  @tailrec private def maxPathDepth(all: Seq[JsValue], current: Depth = 0): Depth = {
+    val nestedValues = all flatMap {
+      case JsArray(values) => values
+      case JsObject(fields) => fields.values
+      case _: JsValue => Nil
+    }
+    if (nestedValues.isEmpty) current
+    else maxPathDepth(nestedValues, current + 1)
+  }
+
+  "Depth" should behave like aCount(Depth)
+
+  "Width" should behave like aCount(Width)
+
+  /* Be careful when defining implicits in an outer class, sometimes the compiler will
+   * not throw an "ambiguous implicit values" exception when the values extend AnyVal.
+   *
+   * Instead of getting a duplicate implicit compiler error, the tests were running with
+   * super.maxDepth and super.maxWidth, so I figured I would sanity check here.
+   *
+   * If you see a compiler error or this test fails, then you must have made something
+   * implicit that maybe shouldn't be, but at least if this test fails then you know
+   * why you are seeing a StackOverflow exception.
+   *
+   * This is primarily just to sanity check that the behavior of implicit Depth and Width
+   * work as intended.
+   */
+  "Depth and Width" should "be differentiated in implicit parameters by type at compile-time" in {
+    val localScope = new JsValueGeneratorsSubclass
+    localScope.verifyImplicitOverrides()
+  }
+
+  "genJsPrimitive" should behave like aPrimitiveJsValue(genJsPrimitive)
+  it should behave like itHasSymmetricJsonSerialization(genJsPrimitive)
+
+  "genJsValue with a depth of 0" should behave like aPrimitiveJsValue(genJsValue(Depth(0)))
+
+  "genJsValue" should behave like aJsValueContainer(genJsValue(_, _))
+  it should behave like itHasSymmetricJsonSerialization(genJsValue())
+
+  "genJsArray" should behave like aJsValueContainer(genJsArray(_, _))
+  it should behave like itHasSymmetricJsonSerialization(genJsArray())
+
+  "genJsObject" should behave like aJsValueContainer(genJsObject(_, _))
+  it should behave like itHasSymmetricJsonSerialization(genJsObject())
+
+  "genSafeBigDecimal" should "generate BigDecimals greater than Double.MaxValue " in {
+    val biggerExists = Prop.exists((big: BigDecimal) => big > Double.MaxValue)
+    val biggerThanDouble = biggerExists(Gen.Parameters.default)
+    assert(!biggerThanDouble.failure)
+  }
+
+  it should "generate BigDecimals smaller than Double.MinValue" in {
+    val smallerExists = Prop.exists((big: BigDecimal) => big < Double.MinValue)
+    val smallerThanDouble = smallerExists(Gen.Parameters.default)
+    assert(!smallerThanDouble.failure)
+  }
+
+  def aCount(count: Int => Counted): Unit = {
+    it should "throw an exception on negative numbers" in {
+      forAll(Gen.negNum[Int]) { n =>
+        an[IllegalArgumentException] shouldBe thrownBy { count(n) }
+      }
+    }
+
+    it should "be identical to zero or positive" in {
+      forAll(Gen.posNum[Int]) { n =>
+        assertResult(n) {
+          count(n).count
+        }
+      }
+    }
+  }
+
+  def aPrimitiveJsValue(genJs: Gen[_ <: JsValue]): Unit = {
+    it should "only contain primitive (non-nested) values" in {
+      forAll(genJs) { json =>
+        assertResult(0) {
+          maxPathDepth(Seq(json)).count
+        }
+      }
+    }
+  }
+
+  def aJsValueContainer(genJs: (Depth, Width) => Gen[_ <: JsValue]): Unit = {
+    it should "should reach a depth greater than 1" in {
+      Prop.exists(genJs(Depth(1), maxWidth)) { json =>
+        maxPathDepth(Seq(json)) > 1
+      }
+    }
+
+    it should "have a depth no larger than provided" in {
+      val genJsWithDepth: Gen[(Int, JsValue)] = for {
+        maxDepth <- Gen.choose(1, maxDepth.depth)
+        js <- genJs(Depth(maxDepth), maxWidth)
+      } yield (maxDepth, js)
+      forAll(genJsWithDepth) { case (max, json) =>
+        assert(maxPathDepth(Seq(json)) <= max)
+      }
+    }
+  }
+
+  def anArbitraryJsValue(genJs: Gen[_ <: JsValue]): Unit = {
+    it should "never generate more depth than the specified depth" in {
+      forAll() { (json: JsValue) =>
+        assert(maxPathDepth(Seq(json)) <= maxDepth)
+      }
+    }
+  }
+
+  def itHasSymmetricJsonSerialization(genJs: Gen[_ <: JsValue]): Unit = {
+    it should "always generate values that can be serialized and deserialized to and from a string" in {
+      forAll() { (json: JsValue) =>
+        assertResult(json) {
+          val serialized = Json.stringify(json)
+          val deserialized = Json.parse(serialized)
+          deserialized
+        }
+      }
+    }
+  }
+}
+
+class JsValueGeneratorsSubclass(implicit localDepth: Depth, localWidth: Width)
+  extends JsValueGenerators
+  with Assertions
+  with TypeCheckedTripleEquals {
+
+  def doVerifyImplicitOverrides(implicit depth: Depth, width: Width): Unit = {
+    assume(depth === localDepth)
+    assume(width === localWidth)
+  }
+
+  def verifyImplicitOverrides(): Unit = doVerifyImplicitOverrides
+}

--- a/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/PlayJsonFormatSpecExample.scala
+++ b/play28-json-tests-sc14/src/test/scala/play/api/libs/json/scalacheck/PlayJsonFormatSpecExample.scala
@@ -1,0 +1,117 @@
+package play.api.libs.json.scalacheck
+
+import org.scalacheck.Shrink.shrink
+import org.scalacheck.ops.ScalaCheckImplicits
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.scalacheck.PlayJsonFormatFlatSpecExample.SampleException
+import play.api.libs.json.scalatest.PlayJsonFormatSpec
+
+case class Example(value: String, nested: Seq[Example])
+
+object Example {
+  implicit val format: OFormat[Example] = Json.format[Example]
+}
+
+trait PlayJsonExampleGenerators {
+
+  def genExample(depth: Int)(implicit arbString: Arbitrary[String]): Gen[Example] =
+    for {
+      str <- arbString.arbitrary
+      nested <- Gen.listOfN(depth, genExample(depth - 1))
+    } yield Example(str, nested)
+
+  implicit def arbExample(implicit arbString: Arbitrary[String]): Arbitrary[Example] = Arbitrary {
+    Gen.choose(0, 5) flatMap genExample
+  }
+
+  implicit val shrinkExample: Shrink[Example] = {
+    val extract = Example.unapply _
+    val rebuild = (Example.apply _).tupled
+    Shrink {
+      example =>
+        val shrinkTupled = shrink(extract(example).get)
+        val stream = shrinkTupled map rebuild
+        stream
+    }
+  }
+}
+
+object PlayJsonExampleGenerators extends PlayJsonExampleGenerators
+
+import play.api.libs.json.scalacheck.PlayJsonExampleGenerators._
+
+/**
+ * No additional tests
+ */
+class PlayJsonFormatSpecExample extends PlayJsonFormatSpec[Example]
+
+/**
+ * Additional [[AnyFlatSpecLike]] tests
+ */
+class PlayJsonFormatFlatSpecExample extends PlayJsonFormatSpec[Example]
+with AnyFlatSpecLike
+with Matchers
+with ScalaCheckImplicits
+with ScalaCheckDrivenPropertyChecks {
+
+  var lastFailReason: Option[String] = None
+  var lastFailCause: Option[Throwable] = None
+  override def doFail(reason: Option[String], cause: Option[Throwable]): Nothing = {
+    lastFailReason = reason
+    lastFailCause = cause
+    super.doFail(reason, cause)
+  }
+
+  "PlayJsonFormatFlatSpecExample" should "allow adding additional specs" in {
+    forAll() { (example: Example) =>
+      assert(Json.toJson(example).as[Example] == example)
+    }
+  }
+
+  it should "call the doFail method when providing a reason" in {
+    lastFailReason = None
+    val reason = "reason"
+    a[TestFailedException] shouldBe thrownBy {
+      fail(reason)
+    }
+    assert(lastFailReason contains reason)
+  }
+
+  it should "call the doFail method when providing a cause" in {
+    lastFailCause = None
+    a[TestFailedException] shouldBe thrownBy {
+      fail(SampleException)
+    }
+    assert(lastFailCause contains SampleException)
+  }
+
+  it should "call the doFail method when providing both a reason and a cause" in {
+    lastFailCause = None
+    lastFailReason = None
+    val reason = "reason"
+    a[TestFailedException] shouldBe thrownBy {
+      fail(reason, SampleException)
+    }
+    assert(lastFailCause contains SampleException)
+    assert(lastFailReason contains reason)
+  }
+
+  "PlayJsonFormatFlatSpecExample.shrink" should "use the implicit shrink" in {
+    val example = genExample(1).randomOrThrow()
+    val ex = intercept[TestFailedException] {
+      val expected = example.copy(nested = Seq())
+      assertSameWithShrink(expected, example, Json.toJson(example))
+    }
+    assert(ex.getSuppressed.head.getMessage contains "shrink")
+  }
+}
+
+object PlayJsonFormatFlatSpecExample {
+
+  case object SampleException extends Throwable
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,10 +19,10 @@ object Dependencies {
   private val Play_2_7_JsonVersion = "2.7.4"
   private val Play_2_8_JsonVersion = "2.8.1"
   private val ScalaCheckOpsVersion = "2.6.0"
+  private val ScalaParallelCollectionsVersion = "1.0.2"
   private val ScalaTest_2 = "2.2.6"
   private val ScalaTest_3 = "3.0.5"
   private val ScalaTest_3_2 = "3.2.7"
-
   private val ScalaTestPlusScalaCheckVersion = "3.2.0.0"
 
   def playJson(playVersion: String): ModuleID = {
@@ -44,6 +44,13 @@ object Dependencies {
     "com.rallyhealth" %% s"scalacheck-ops$suffix" % ScalaCheckOpsVersion
   }
 
+  def scalaParallelCollections(scalaVersion: String): Seq[ModuleID] = scalaVersion match {
+    case Scala_2_13 => Seq(
+      "org.scala-lang.modules" %% "scala-parallel-collections" % ScalaParallelCollectionsVersion
+    )
+    case _ => Seq()
+  }
+
   def scalaTest(scalaCheckVersion: String): ModuleID = {
     val version = scalaCheckVersion match {
       case ScalaCheck_1_12 => ScalaTest_2
@@ -53,11 +60,11 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % version
   }
 
-  def scalaTestPlusScalaCheck(scalaCheckVersion: String): ModuleID = {
-    val version = scalaCheckVersion match {
-      case ScalaCheck_1_14 => ScalaTestPlusScalaCheckVersion
-    }
-    "org.scalatestplus" %% "scalacheck-1-14" % version
+  def scalaTestPlusScalaCheck(scalaCheckVersion: String): Seq[ModuleID] = scalaCheckVersion match {
+    case ScalaCheck_1_14 => Seq(
+      "org.scalatestplus" %% "scalacheck-1-14" % ScalaTestPlusScalaCheckVersion
+    )
+    case _ => Seq()
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,33 +2,34 @@ import sbt._
 
 object Dependencies {
 
-  final val Play_2_5 = "2.5.18"
-  final val Play_2_6 = "2.6.19"
-  final val Play_2_7 = "2.7.4"
-  final val Play_2_8 = "2.8.3"
+  final val Play_2_5 = "2.5.19"
+  final val Play_2_6 = "2.6.25"
+  final val Play_2_7 = "2.7.9"
+  final val Play_2_8 = "2.8.7"
 
   final val Scala_2_11 = "2.11.12"
-  final val Scala_2_12 = "2.12.6"
-  final val Scala_2_13 = "2.13.1"
+  final val Scala_2_12 = "2.12.12"
+  final val Scala_2_13 = "2.13.5"
 
-  final val ScalaCheck_1_12 = "1.12.5"
-  final val ScalaCheck_1_13 = "1.13.4"
+  final val ScalaCheck_1_12 = "1.12.6"
+  final val ScalaCheck_1_13 = "1.13.5"
   final val ScalaCheck_1_14 = "1.14.3"
 
   private val Play_2_6_JsonVersion = "2.6.10"
+  private val Play_2_7_JsonVersion = "2.7.4"
   private val Play_2_8_JsonVersion = "2.8.1"
-  private val ScalaCheckOpsVersion = "2.2.1"
+  private val ScalaCheckOpsVersion = "2.6.0"
   private val ScalaTest_2 = "2.2.6"
   private val ScalaTest_3 = "3.0.5"
-  private val ScalaTest_3_1 = "3.1.0"
+  private val ScalaTest_3_2 = "3.2.7"
 
-  private val ScalaTestPlusScalaCheck_1_14_Version = "3.1.0.0"
+  private val ScalaTestPlusScalaCheckVersion = "3.2.0.0"
 
   def playJson(playVersion: String): ModuleID = {
     val playJsonVersion = playVersion match {
       case Play_2_5 => Play_2_5
       case Play_2_6 => Play_2_6_JsonVersion
-      case Play_2_7 => Play_2_7
+      case Play_2_7 => Play_2_7_JsonVersion
       case Play_2_8 => Play_2_8_JsonVersion
     }
     "com.typesafe.play" %% "play-json" % playJsonVersion
@@ -47,14 +48,14 @@ object Dependencies {
     val version = scalaCheckVersion match {
       case ScalaCheck_1_12 => ScalaTest_2
       case ScalaCheck_1_13 => ScalaTest_3
-      case ScalaCheck_1_14 => ScalaTest_3_1
+      case ScalaCheck_1_14 => ScalaTest_3_2
     }
     "org.scalatest" %% "scalatest" % version
   }
 
   def scalaTestPlusScalaCheck(scalaCheckVersion: String): ModuleID = {
     val version = scalaCheckVersion match {
-      case ScalaCheck_1_14 => ScalaTestPlusScalaCheck_1_14_Version
+      case ScalaCheck_1_14 => ScalaTestPlusScalaCheckVersion
     }
     "org.scalatestplus" %% "scalacheck-1-14" % version
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
-resolvers += Classpaths.sbtPluginReleases
-resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",
   url("https://dl.bintray.com/content/sbt/sbt-plugin-releases")
 )(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.2.2")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
### Summary

I am upgrading all the libraries and sbt plugins in preparation for moving everything to Maven Central.

In the process, I noticed that Play 2.8 artifacts were empty:

```
jar -tf /Users/jeff.may/Downloads/play28-json-ops-v4_2.12-4.1.0-sources.jar
META-INF/MANIFEST.MF
```

```
jar -tf /Users/jeff.may/Downloads/play28-json-ops-v4_2.13-4.1.0-sources.jar
META-INF/MANIFEST.MF
```

These changes upgrade everything and fix the packaging issues of Play 2.8. It turns out that I needed to make yet another copy of the code base to avoid breaking backwards compatibility with the Play 2.7 / Scala 2.13 version.

The new copy of the code is designed to be cross-compiled for all versions that depend on Scala 2.13 (regardless of Play version). Initially, I deleted the Play 2.7 / Scala 2.13 version of the code, in hopes that I could shim in the new Scala 2.13 code, but it was causing too many binary compatibility issues that I couldn't resolve them all. Instead, we will just have to remove the Play 2.7 / Scala 2.13 copy of the code on the next major version.

### Changes

- Upgrade to sbt 1.5.0 and use dynver and mima plugins directly 
  - Upgrade sbt to 1.5.0
  - Remove sbt-git-versioning
  - Add sbt-dynver and sbt-mima plugins
  - Upgrade Scala versions
  - Upgrade scalatest to 3.2.7
  - Upgrade scalacheck-ops to 2.6.0
  - Update travis build to match
  - Update .gitignore for new version of sbt
  - Fix flaky test
  - Use contains instead of ==
  - Use randomOrThrow() instead of .getOrThrow
- Publish Play 2.8 code properly
  - Create a shared play-json-ops-common-213 for Scala 2.13 implementations
  - Create a shared play28-json-ops project for shared Play 2.8 implementations
  - Update the build.sbt to cross-compile these projects appropriately and fail loud when versions are unmatched