### PR TITLE
Publish legacy 2.0.1 to Sonatype / Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 
 # sbt specific
+.bsp
 .cache
 .history
 .lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,26 @@
 language: scala
 scala:
-  - 2.10.6
-  - 2.11.8
+  - 2.13.5
 jdk:
-  - oraclejdk8
+  - openjdk8
+
+before_script:
+  # Download sbt because Travis can't find it automatically :(
+  - mkdir -p $HOME/.sbt/launchers/1.5.0/
+  - curl -L -o $HOME/.sbt/launchers/1.5.0/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar
 
 script:
-  - sbt clean coverage test coverageReport && sbt coverageAggregate
-after_success:
-  - sbt coveralls
+  - sbt clean +test
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+# Avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
-
+    - $HOME/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,30 @@
 name := "play-json-ops-root"
-organization in ThisBuild := "me.jeffmay"
-organizationName in ThisBuild := "Jeff May"
 
-version in ThisBuild := "2.0.0"
-scalaVersion in ThisBuild := "2.11.11"
+val Scala_2_11 = "2.11.11"
 
-// don't publish the surrounding multi-project build
-publish := {}
-publishLocal := {}
+ThisBuild / scalaVersion := Scala_2_11
+
+ThisBuild / organization := "com.rallyhealth"
+ThisBuild / organizationName := "Rally Health"
+
+ThisBuild / versionScheme := Some("early-semver")
+ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
+
+ThisBuild / homepage := Some(url("https://github.com/rallyhealth/play-json-ops"))
+ThisBuild / developers := List(
+  Developer(id = "jeffmay", name = "Jeff May", email = "jeff.n.may@gmail.com", url = url("https://github.com/jeffmay")),
+)
+
+ThisBuild / resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
+
+// reload sbt when the build files change
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
+// don't publish the aggregate root project
+publish / skip := true
+
+// don't search for previous artifact of the root project
+ThisBuild / mimaFailOnNoPrevious := false
 
 def commonProject(id: String): Project = {
   Project(id, file(id)).settings(
@@ -21,26 +38,14 @@ def commonProject(id: String): Project = {
       "-encoding", "UTF-8"
     ),
 
-    resolvers ++= Seq(
-      "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
-      "jeffmay at bintray" at "https://dl.bintray.com/jeffmay/maven"
-    ),
-
-    ivyScala := ivyScala.value map {
-      _.copy(overrideScalaVersion = true)
-    },
-
     // don't publish the test code as an artifact anymore, since we have playJsonTests
-    publishArtifact in Test := false,
+    Test / publishArtifact := false,
 
     // disable compilation of ScalaDocs, since this always breaks on links
-    sources in(Compile, doc) := Seq.empty,
+    Compile / doc / sources := Seq.empty,
 
     // disable publishing empty ScalaDocs
-    publishArtifact in(Compile, packageDoc) := false,
-
-    licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
-
+    Compile / packageDoc / publishArtifact := false
   )
 }
 
@@ -73,9 +78,8 @@ def playJsonTests(includePlayVersion: String, includeScalatestVersion: String): 
   val projectPath = s"play$playSuffix-json-tests"
   commonProject(id).settings(
     // set the source code directories to the shared project root
-    sourceDirectory := file(s"$projectPath/src").getAbsoluteFile,
-    (sourceDirectory in Compile) := file(s"$projectPath/src/main").getAbsoluteFile,
-    (sourceDirectory in Test) := file(s"$projectPath/src/test").getAbsoluteFile,
+    (Compile / sourceDirectory) := file(s"$projectPath/src/main").getAbsoluteFile,
+    (Test / sourceDirectory) := file(s"$projectPath/src/test").getAbsoluteFile,
     libraryDependencies ++= Seq(
       Dependencies.scalatest(includeScalatestVersion),
       Dependencies.scalacheckOps(includeScalatestVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val scalatest2Version = "2.2.6"
   val scalatest3Version = "3.0.4"
-  private val scalacheckOpsVersion = "1.5.0"
+  private val scalacheckOpsVersion = "1.5.1"
 
   def playJson(playVersion: String): ModuleID = {
     "com.typesafe.play" %% "play-json" % playVersion
@@ -15,10 +15,10 @@ object Dependencies {
 
   def scalacheckOps(scalatestVersion: String): ModuleID = {
     val suffix = scalatestVersion match {
-      case `scalatest2Version` => ""
+      case `scalatest2Version` => "_1-12"
       case `scalatest3Version` => "_1-13"
     }
-    "me.jeffmay" %% s"scalacheck-ops$suffix" % scalacheckOpsVersion
+    "com.rallyhealth" %% s"scalacheck-ops$suffix" % scalacheckOpsVersion
   }
 
   def scalatest(scalatestVersion: String): ModuleID = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,4 @@
-resolvers += Classpaths.sbtPluginReleases
-
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases")
-)(Resolver.ivyStylePatterns)
-
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,22 @@
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "com.rallyhealth"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// publish to Maven Central
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+ThisBuild / publishTo := Some {
+  if (isSnapshot.value)
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/snapshots"))
+  else
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/releases"))
+}
+
+// add SNAPSHOT to non-release versions so they are not published to the main repo
+ThisBuild / dynverSonatypeSnapshots := true
+// Use '-' instead of '+' for simpler snapshot URLs
+ThisBuild / dynverSeparator := "-"
+
+import xerial.sbt.Sonatype.GitHubHosting
+sonatypeProjectHosting := Some(GitHubHosting("rallyhealth", "play-json-ops", "jeff.n.may@gmail.com"))


### PR DESCRIPTION
In a similar vein as https://github.com/rallyhealth/scalacheck-ops/pull/38, we are using that scalacheck-ops version to republish this older version of play-json-ops to Sonatype. This is a one-time legacy support migration.

----

@jiwanpokharel was having issues with this artifact after Bintray was shut down. We tried investigating various combinations of versions to avoid major breaking changes on downstream dependencies but could not find a combination of cached versions that would work.

This is a one-time legacy import into Sonatype for this really old version of artifacts. This branch will not be supported beyond this stop-gap fix. Any upgrade from here will need to use a version >= 4.4.0